### PR TITLE
Implement API key management per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ POST /api/login { email, password }
 
 Envie o token nas próximas requisições em `Authorization: Bearer <token>`.
 
+Cada usuário também possui uma **API Key** única, necessária para acessar a rota
+`POST /api/postback`. Consulte a sua chave em `/api/integrations/info` e, caso
+precise, gere uma nova em `/api/integrations/regenerate`.
+
 ---
 
 ## ⚖️ Licença

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ const paymentController = require('./src/controllers/paymentController');
 const webhookRastreioController = require('./src/controllers/webhookRastreioController');
 const authController = require('./src/controllers/authController');
 const authMiddleware = require('./src/middleware/auth');
+const apiKeyMiddleware = require('./src/middleware/apiKey');
 const planCheck = require('./src/middleware/planCheck');
 
 
@@ -183,6 +184,9 @@ const startApp = async () => {
         app.post('/api/register', authController.register);
         app.post('/api/login', authController.login);
 
+        // Postback - validação por API Key
+        app.post('/api/postback', apiKeyMiddleware, integrationsController.receberPostback);
+
         // Middleware de autenticação para rotas abaixo
         app.use(authMiddleware);
 
@@ -227,7 +231,6 @@ const startApp = async () => {
         app.get('/api/reports/summary', reportsController.getReportSummary);
 
         // Rotas de Integrações (UNIFICADAS)
-        app.post('/api/postback', integrationsController.receberPostback);
         app.get('/api/integrations/info', integrationsController.getIntegrationInfo);
         app.post('/api/integrations/regenerate', integrationsController.regenerateApiKey);
 

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -11,7 +11,7 @@ exports.register = async (req, res) => {
         const existing = await userService.findUserByEmail(req.db, email);
         if (existing) return res.status(409).json({ error: 'Usuário já existe.' });
         const user = await userService.createUser(req.db, email, password);
-        res.status(201).json({ id: user.id, email: user.email });
+        res.status(201).json({ id: user.id, email: user.email, apiKey: user.api_key });
     } catch (err) {
         res.status(500).json({ error: 'Falha ao registrar usuário.' });
     }

--- a/src/middleware/apiKey.js
+++ b/src/middleware/apiKey.js
@@ -1,0 +1,15 @@
+const userService = require('../services/userService');
+
+module.exports = async (req, res, next) => {
+    const key = req.query.key || req.headers['x-api-key'];
+    if (!key) return res.status(401).json({ error: 'API key ausente' });
+    try {
+        const user = await userService.findUserByApiKey(req.db, key);
+        if (!user) return res.status(401).json({ error: 'API key inválida' });
+        req.user = { id: user.id, email: user.email }; // minimal info
+        next();
+    } catch (err) {
+        console.error('Erro na autenticação por API key', err);
+        res.status(500).json({ error: 'Falha na autenticação' });
+    }
+};

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,12 +1,18 @@
 const bcrypt = require('bcryptjs');
+const crypto = require('crypto');
+
+function generateApiKey() {
+    return crypto.randomBytes(20).toString('hex');
+}
 
 function createUser(db, email, password) {
     return new Promise((resolve, reject) => {
         const hashed = bcrypt.hashSync(password, 10);
-        const stmt = db.prepare('INSERT INTO users (email, password) VALUES (?, ?)');
-        stmt.run(email, hashed, function(err) {
+        const apiKey = generateApiKey();
+        const stmt = db.prepare('INSERT INTO users (email, password, api_key) VALUES (?, ?, ?)');
+        stmt.run(email, hashed, apiKey, function(err) {
             if (err) return reject(err);
-            resolve({ id: this.lastID, email });
+            resolve({ id: this.lastID, email, api_key: apiKey });
         });
         stmt.finalize();
     });
@@ -21,4 +27,38 @@ function findUserByEmail(db, email) {
     });
 }
 
-module.exports = { createUser, findUserByEmail };
+function findUserById(db, id) {
+    return new Promise((resolve, reject) => {
+        db.get('SELECT * FROM users WHERE id = ?', [id], (err, row) => {
+            if (err) return reject(err);
+            resolve(row);
+        });
+    });
+}
+
+function findUserByApiKey(db, apiKey) {
+    return new Promise((resolve, reject) => {
+        db.get('SELECT * FROM users WHERE api_key = ?', [apiKey], (err, row) => {
+            if (err) return reject(err);
+            resolve(row);
+        });
+    });
+}
+
+function regenerateApiKey(db, userId) {
+    return new Promise((resolve, reject) => {
+        const newKey = generateApiKey();
+        db.run('UPDATE users SET api_key = ? WHERE id = ?', [newKey, userId], function(err) {
+            if (err) return reject(err);
+            resolve(newKey);
+        });
+    });
+}
+
+module.exports = {
+    createUser,
+    findUserByEmail,
+    findUserById,
+    findUserByApiKey,
+    regenerateApiKey
+};


### PR DESCRIPTION
## Summary
- add API key generation and management for users
- enforce API key authentication on `/api/postback`
- allow viewing and regenerating API key via integration routes
- document how to use the API key

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858d4417eb48321a574d707bae11e3e