### PR TITLE
Implement rate limit by tracking plan usage

### DIFF
--- a/server.js
+++ b/server.js
@@ -184,8 +184,8 @@ const startApp = async () => {
         app.post('/api/register', authController.register);
         app.post('/api/login', authController.login);
 
-        // Postback - validação por API Key
-        app.post('/api/postback', apiKeyMiddleware, integrationsController.receberPostback);
+        // Postback - validação por API Key + controle de plano
+        app.post('/api/postback', apiKeyMiddleware, planCheck, integrationsController.receberPostback);
 
         // Middleware de autenticação para rotas abaixo
         app.use(authMiddleware);
@@ -224,23 +224,23 @@ const startApp = async () => {
         // Rotas de SITE RASTREIO
         app.post('/api/webhook-site-rastreio', webhookRastreioController.receberWebhook);
         // Rotas de Automações
-        app.get('/api/automations', automationsController.listarAutomacoes);
-        app.post('/api/automations', automationsController.salvarAutomacoes);
+        app.get('/api/automations', planCheck, automationsController.listarAutomacoes);
+        app.post('/api/automations', planCheck, automationsController.salvarAutomacoes);
 
         // Rotas de Relatórios
-        app.get('/api/reports/summary', reportsController.getReportSummary);
+        app.get('/api/reports/summary', planCheck, reportsController.getReportSummary);
 
         // Rotas de Integrações (UNIFICADAS)
-        app.get('/api/integrations/info', integrationsController.getIntegrationInfo);
-        app.post('/api/integrations/regenerate', integrationsController.regenerateApiKey);
+        app.get('/api/integrations/info', planCheck, integrationsController.getIntegrationInfo);
+        app.post('/api/integrations/regenerate', planCheck, integrationsController.regenerateApiKey);
 
         // Rotas do WhatsApp
         app.get('/api/whatsapp/status', (req, res) => res.json({ status: whatsappStatus, qrCode: qrCodeData, botInfo: botInfo }));
-        app.post('/api/whatsapp/connect', (req, res) => {
+        app.post('/api/whatsapp/connect', planCheck, (req, res) => {
             connectToWhatsApp();
             res.status(202).json({ message: "Processo de conexão iniciado." });
         });
-        app.post('/api/whatsapp/disconnect', async (req, res) => {
+        app.post('/api/whatsapp/disconnect', planCheck, async (req, res) => {
             await disconnectFromWhatsApp();
             res.status(200).json({ message: "Desconectado com sucesso." });
         });

--- a/src/controllers/pedidosController.js
+++ b/src/controllers/pedidosController.js
@@ -77,10 +77,6 @@ exports.criarPedido = async (req, res) => {
         }
         
         const pedidoCriado = await pedidoService.criarPedido(db, { ...req.body, telefone: telefoneNormalizado }, client, clienteId);
-        if (req.subscription) {
-            const subscriptionService = require('../services/subscriptionService');
-            await subscriptionService.incrementUsage(db, req.subscription.id);
-        }
         
         // Notifica o frontend
         req.broadcast({ type: 'novo_contato', pedido: pedidoCriado });

--- a/src/middleware/planCheck.js
+++ b/src/middleware/planCheck.js
@@ -11,6 +11,9 @@ module.exports = async (req, res, next) => {
         if (sub.monthly_limit !== -1 && sub.usage >= sub.monthly_limit) {
             return res.status(403).json({ error: 'Limite do plano excedido' });
         }
+        await subscriptionService.incrementUsage(req.db, sub.id);
+        // Atualiza o uso local para evitar novo fetch em handlers
+        sub.usage += 1;
         req.subscription = sub;
         next();
     } catch (e) {


### PR DESCRIPTION
## Summary
- increment plan usage for every protected request in `planCheck`
- remove manual usage increment when creating orders
- apply plan checks to more routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858db260a6083218aa1e5f893b1673d