### PR TITLE
Implement Stripe payment webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ precise, gere uma nova em `/api/integrations/regenerate`.
 
 ---
 
+## 💳 Pagamentos
+
+1. Defina as variáveis `STRIPE_SECRET`, `PAY_SUCCESS_URL`, `PAY_CANCEL_URL`, `PAY_WEBHOOK_URL` e `PAY_WEBHOOK_SECRET` no `.env`.
+2. No painel do Stripe acesse **Developers > Webhooks** e crie um endpoint apontando para o valor de `PAY_WEBHOOK_URL`.
+3. Adicione o evento `checkout.session.completed` e copie a chave secreta fornecida para `PAY_WEBHOOK_SECRET`.
+
+Com isso, quando o pagamento for confirmado, o servidor atualizará o status da sua assinatura automaticamente.
+
+---
+
 ## ⚖️ Licença
 
 MIT — Livre para usar e modificar.

--- a/server.js
+++ b/server.js
@@ -173,6 +173,9 @@ const startApp = async () => {
         app.set('db', db);
         console.log("Banco de dados pronto.");
 
+        // Webhook precisa do corpo raw para validação
+        app.post('/api/payment/webhook', express.raw({ type: 'application/json' }), paymentController.handleWebhook);
+
         app.use(express.json());
         app.use(express.static('public'));
 

--- a/src/controllers/paymentController.js
+++ b/src/controllers/paymentController.js
@@ -1,5 +1,6 @@
 const Stripe = require('stripe');
 const stripe = new Stripe(process.env.STRIPE_SECRET || '', { apiVersion: '2022-11-15' });
+const subscriptionService = require('../services/subscriptionService');
 
 exports.createCheckout = async (req, res) => {
     const { planId } = req.body;
@@ -14,6 +15,7 @@ exports.createCheckout = async (req, res) => {
         if (!plan) return res.status(404).json({ error: 'Plano não encontrado' });
         const session = await stripe.checkout.sessions.create({
             mode: 'payment',
+            client_reference_id: req.user.id,
             line_items: [{ price_data: { currency: 'brl', product_data: { name: plan.name }, unit_amount: Math.round(plan.price*100) }, quantity: 1 }],
             success_url: process.env.PAY_SUCCESS_URL || 'https://example.com/success',
             cancel_url: process.env.PAY_CANCEL_URL || 'https://example.com/cancel'
@@ -23,4 +25,29 @@ exports.createCheckout = async (req, res) => {
         console.error(err);
         res.status(500).json({ error: 'Falha ao criar checkout' });
     }
+};
+
+exports.handleWebhook = async (req, res) => {
+    const sig = req.headers['stripe-signature'];
+    let event;
+    try {
+        event = stripe.webhooks.constructEvent(req.body, sig, process.env.PAY_WEBHOOK_SECRET || '');
+    } catch (err) {
+        console.error('Webhook signature verification failed.', err.message);
+        return res.status(400).send(`Webhook Error: ${err.message}`);
+    }
+
+    if (event.type === 'checkout.session.completed') {
+        const session = event.data.object;
+        const userId = session.client_reference_id;
+        if (userId) {
+            try {
+                await subscriptionService.updateSubscriptionStatus(req.db, userId, 'active');
+            } catch (e) {
+                console.error('Erro ao atualizar assinatura:', e);
+            }
+        }
+    }
+
+    res.json({ received: true });
 };

--- a/src/services/subscriptionService.js
+++ b/src/services/subscriptionService.js
@@ -59,4 +59,13 @@ function updateUserPlan(db, userId, planId) {
     });
 }
 
-module.exports = { getUserSubscription, incrementUsage, resetUsageIfNeeded, createSubscription, updateUserPlan };
+function updateSubscriptionStatus(db, userId, status) {
+    return new Promise((resolve, reject) => {
+        db.run('UPDATE subscriptions SET status = ? WHERE user_id = ?', [status, userId], function(err) {
+            if (err) return reject(err);
+            resolve({ changes: this.changes });
+        });
+    });
+}
+
+module.exports = { getUserSubscription, incrementUsage, resetUsageIfNeeded, createSubscription, updateUserPlan, updateSubscriptionStatus };


### PR DESCRIPTION
## Summary
- create Stripe webhook handler and route
- update subscription service with status updater
- store user ID in checkout session and mark subscription active on completion
- document Stripe webhook configuration

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859c67d6cd08321a1e1c57d7cbb4844