### PR TITLE
Add env example and improve config docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Exemplo de configurações de ambiente
+# Copie este arquivo para ".env" e preencha com seus valores
+
+# Chave usada para assinar JWTs
+JWT_SECRET=
+
+# Chave de acesso à API do Site Rastreio
+SITERASTREIO_API_KEY=
+
+# Chave para autenticar postbacks da Braip
+BRAIP_SECRET=
+
+# Configurações de pagamento (Stripe)
+STRIPE_SECRET=
+PAY_SUCCESS_URL=
+PAY_CANCEL_URL=
+PAY_WEBHOOK_URL=
+PAY_WEBHOOK_SECRET=

--- a/README.md
+++ b/README.md
@@ -41,12 +41,17 @@ cd bot-rastreamento
 # Instalar dependências
 npm install
 
-# Criar o arquivo `.env`
-# (preencha com as variáveis necessárias, como `SITERASTREIO_API_KEY` e `JWT_SECRET`)
-touch .env
+# Copiar o arquivo de exemplo de variáveis de ambiente
+cp .env.example .env
 ```
 
-Edite o `.env` com suas chaves e URLs de callback.
+Edite o `.env` com suas chaves e URLs de callback. As principais variáveis são:
+- `JWT_SECRET` – chave usada para assinar os tokens JWT
+- `SITERASTREIO_API_KEY` – chave da API do Site Rastreio
+- `BRAIP_SECRET` – autenticação para postbacks da Braip
+- `STRIPE_SECRET` – chave secreta do Stripe
+- `PAY_SUCCESS_URL` e `PAY_CANCEL_URL` – páginas de retorno do checkout
+- `PAY_WEBHOOK_URL` e `PAY_WEBHOOK_SECRET` – endpoint e segredo do webhook de pagamento
 
 ---
 

--- a/src/controllers/integrationsController.js
+++ b/src/controllers/integrationsController.js
@@ -3,9 +3,8 @@ const pedidoService = require('../services/pedidoService');
 const userService = require('../services/userService');
 
 // Num sistema SaaS, esta chave viria do banco de dados de um utilizador específico.
-
-// Num sistema SaaS, esta chave também estaria associada à conta do utilizador.
-const CHAVE_SECRETA_DA_PLATAFORMA = "COLE_A_SUA_CHAVE_UNICA_DA_BRAIP_AQUI";
+// Aqui é lida de uma variável de ambiente para facilitar a configuração
+const CHAVE_SECRETA_DA_PLATAFORMA = process.env.BRAIP_SECRET || '';
 
 /**
  * Função 1: Recebe o postback de uma plataforma externa.


### PR DESCRIPTION
## Summary
- provide `.env.example` template with all required keys
- document environment variables in the README
- load Braip secret from `BRAIP_SECRET` env variable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858e299b9208321858eb45f6ae00141