### PR TITLE
Allow configurable server port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ SITERASTREIO_API_KEY=
 # Chave para autenticar postbacks da Braip
 BRAIP_SECRET=
 
+# Porta em que o servidor Express irá rodar (opcional)
+PORT=3000
+
 # Configurações de pagamento (Stripe)
 STRIPE_SECRET=
 PAY_SUCCESS_URL=

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Edite o `.env` com suas chaves e URLs de callback. As principais variáveis são
 - `JWT_SECRET` – chave usada para assinar os tokens JWT
 - `SITERASTREIO_API_KEY` – chave da API do Site Rastreio
 - `BRAIP_SECRET` – autenticação para postbacks da Braip
+- `PORT` – porta em que o servidor irá rodar (padrão 3000)
 - `STRIPE_SECRET` – chave secreta do Stripe
 - `PAY_SUCCESS_URL` e `PAY_CANCEL_URL` – páginas de retorno do checkout
 - `PAY_WEBHOOK_URL` e `PAY_WEBHOOK_SECRET` – endpoint e segredo do webhook de pagamento

--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ let venomClient = null;
 let botInfo = null;
 
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 const server = http.createServer(app);
 const wss = new WebSocketServer({ server });
 const clients = new Set();


### PR DESCRIPTION
## Summary
- allow configuring Express server port via `PORT` env var
- document `PORT` setting in `.env.example`
- mention `PORT` option in README setup steps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b5c4833008321b589b751a10cd351