### PR TITLE
Allow custom SQLite path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ PAY_SUCCESS_URL=
 PAY_CANCEL_URL=
 PAY_WEBHOOK_URL=
 PAY_WEBHOOK_SECRET=
+
+# Caminho opcional para o arquivo SQLite
+DB_PATH=

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Edite o `.env` com suas chaves e URLs de callback. As principais variáveis são
 - `STRIPE_SECRET` – chave secreta do Stripe
 - `PAY_SUCCESS_URL` e `PAY_CANCEL_URL` – páginas de retorno do checkout
 - `PAY_WEBHOOK_URL` e `PAY_WEBHOOK_SECRET` – endpoint e segredo do webhook de pagamento
+- `DB_PATH` – caminho para o arquivo SQLite (opcional)
 
 ---
 

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -1,7 +1,7 @@
 // src/database/database.js
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
-const DB_PATH = path.join(__dirname, '../../automaza.db');
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, '../../automaza.db');
 
 const initDb = () => {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- make DB path configurable via DB_PATH env var
- document DB_PATH variable in .env.example
- mention DB_PATH in README installation steps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b5c499c6c8321b844b7f4adf5af9b