### PR TITLE
Add toggle for auto contact creation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -243,10 +243,17 @@
                         <div id="settings-connection-status">
                             <p>Status atual: <strong id="settings-status-text">Desconhecido</strong></p>
                         </div>
-                        <div id="qr-code-container"></div>
-                        <div class="settings-actions">
-                            <button id="btn-conectar" class="btn-settings-action connect"><span>Conectar WhatsApp</span></button>
-                            <button id="btn-desconectar" class="btn-settings-action disconnect"><span>Desconectar</span></button>
+                    <div id="qr-code-container"></div>
+                    <div class="settings-actions">
+                        <button id="btn-conectar" class="btn-settings-action connect"><span>Conectar WhatsApp</span></button>
+                        <button id="btn-desconectar" class="btn-settings-action disconnect"><span>Desconectar</span></button>
+                    </div>
+                    </div>
+                    <div class="settings-card">
+                        <h3>Criar contato automaticamente ao receber nova mensagem</h3>
+                        <div class="toggle-container">
+                            <label class="switch"><input type="checkbox" id="toggle-create-contact"><span class="slider round"></span></label>
+                            <span id="toggle-create-contact-label" class="toggle-label">Desativado</span>
                         </div>
                     </div>
                 </div>

--- a/public/style.css
+++ b/public/style.css
@@ -163,6 +163,8 @@ body {
 .btn-settings-action.disconnect { background-color: var(--error-color); }
 .qr-expired { padding: 20px; border: 1px dashed var(--border-color); border-radius: 8px; display: flex; flex-direction: column; align-items: center; gap: 15px; }
 .qr-expired p { font-weight: 600; color: var(--error-color); }
+# Estilo para card de configurações
+.settings-card { background-color: #ffffff; border: 1px solid var(--border-color); border-radius: 12px; padding: 25px; margin-top: 25px; width: 100%; max-width: 400px; }
 #settings-profile-info { display: flex; flex-direction: column; align-items: center; gap: 5px; margin-bottom: 25px; }
 #settings-bot-avatar { width: 80px; height: 80px; border-radius: 50%; object-fit: cover; border: 4px solid var(--sidebar-bg); box-shadow: 0 0 0 2px var(--border-color); margin-bottom: 10px; }
 #settings-bot-name { font-size: 1.25rem; font-weight: 600; color: var(--text-color); margin: 0; }

--- a/src/controllers/settingsController.js
+++ b/src/controllers/settingsController.js
@@ -1,0 +1,22 @@
+const settingsService = require('../services/settingsService');
+
+exports.getContactCreationSetting = async (req, res) => {
+    try {
+        const value = await settingsService.getSetting(req.db, req.user.id);
+        res.json({ create_contact_on_message: Boolean(value) });
+    } catch (err) {
+        console.error('Erro ao buscar configuração', err);
+        res.status(500).json({ error: 'Falha ao obter configuração' });
+    }
+};
+
+exports.updateContactCreationSetting = async (req, res) => {
+    const enabled = req.body.enabled ? 1 : 0;
+    try {
+        await settingsService.updateSetting(req.db, req.user.id, enabled);
+        res.json({ message: 'Configuração atualizada', create_contact_on_message: Boolean(enabled) });
+    } catch (err) {
+        console.error('Erro ao atualizar configuração', err);
+        res.status(500).json({ error: 'Falha ao atualizar configuração' });
+    }
+};

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -1,0 +1,29 @@
+const DEFAULT_SETTING = 1;
+
+function getSetting(db, userId) {
+    return new Promise((resolve, reject) => {
+        db.get('SELECT create_contact_on_message FROM user_settings WHERE user_id = ?', [userId], (err, row) => {
+            if (err) return reject(err);
+            resolve(row ? row.create_contact_on_message : DEFAULT_SETTING);
+        });
+    });
+}
+
+function updateSetting(db, userId, value) {
+    const val = value ? 1 : 0;
+    return new Promise((resolve, reject) => {
+        db.run('UPDATE user_settings SET create_contact_on_message = ? WHERE user_id = ?', [val, userId], function(err){
+            if (err) return reject(err);
+            if (this.changes === 0) {
+                db.run('INSERT INTO user_settings (user_id, create_contact_on_message) VALUES (?, ?)', [userId, val], function(err2){
+                    if (err2) return reject(err2);
+                    resolve();
+                });
+            } else {
+                resolve();
+            }
+        });
+    });
+}
+
+module.exports = { getSetting, updateSetting };


### PR DESCRIPTION
## Summary
- add table `user_settings` to store user preferences
- create service and controller for user settings
- allow enabling/disabling automatic contact creation
- expose GET/PUT `/api/settings/contact-creation`
- display toggle in settings page
- fix bot session to respect owner setting before creating contacts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b5f6e0dc48321aa4b1be1058ee9f9