### PR TITLE
Fix plan persistence and admin page access

### DIFF
--- a/src/database/database.js
+++ b/src/database/database.js
@@ -187,6 +187,7 @@ const initDb = () => {
                         return reject(err);
                     }
                     console.log("✔️ Tabela 'subscriptions' pronta.");
+                    db.run(`CREATE UNIQUE INDEX IF NOT EXISTS idx_subscriptions_user ON subscriptions(user_id)`);
                 });
 
                     // Tabela de Configurações de Integração


### PR DESCRIPTION
## Summary
- ensure subscriptions use unique index and upsert on user_id
- serve admin HTML without auth header requirement

## Testing
- `node -e "require('./src/database/database.js').initDb().then(db=>{console.log('ok init');db.close();})"`


------
https://chatgpt.com/codex/tasks/task_e_685b7f2b41b8832185969f4138fcc420