### PR TITLE
Add admin creation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ O acompanhamento dos pedidos é feito de forma automática enquanto o WhatsApp e
 node index.js
 ```
 
+### 3. Criar ou promover administradores
+
+Para gerenciar contas de administrador via terminal execute o script `criar-admin.js`:
+
+```bash
+node criar-admin.js
+```
+
+Ele irá perguntar o e-mail e, se o usuário não existir, será criado como administrador. Caso já exista, você poderá promovê-lo.
+
 ---
 
 ## 📚 Estrutura do Projeto

--- a/criar-admin.js
+++ b/criar-admin.js
@@ -1,0 +1,42 @@
+require('dotenv').config();
+const readline = require('readline');
+const { initDb } = require('./src/database/database');
+const userService = require('./src/services/userService');
+
+(async () => {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const question = (q) => new Promise(resolve => rl.question(q, resolve));
+
+  const db = await initDb().catch(err => {
+    console.error('Erro ao conectar ao banco de dados:', err);
+    process.exit(1);
+  });
+
+  try {
+    const email = await question('Digite o e-mail para o novo administrador: ');
+    const existing = await userService.findUserByEmail(db, email);
+
+    if (existing) {
+      if (existing.is_admin) {
+        console.log('Este usuário já é administrador.');
+      } else {
+        const ans = await question('Este usuário já existe. Deseja promovê-lo a administrador? (s/n) ');
+        if (ans.trim().toLowerCase() === 's') {
+          await userService.updateUser(db, existing.id, { is_admin: 1 });
+          console.log('Usuário promovido a administrador.');
+        } else {
+          console.log('Nenhuma alteração realizada.');
+        }
+      }
+    } else {
+      const password = await question('Digite a senha: ');
+      const user = await userService.createUser(db, email, password, 1, 1);
+      console.log(`Administrador criado com ID ${user.id}.`);
+    }
+  } catch (err) {
+    console.error('Erro ao processar:', err);
+  } finally {
+    rl.close();
+    db.close();
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "create-admin": "node criar-admin.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `criar-admin.js` script for admin management
- document how to run the script in README
- expose `npm run create-admin` via package.json

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685be5bd34e08321986573be37a5a833