### PR TITLE
Implement postback secret field on integrations

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -216,6 +216,14 @@
                         <button class="btn-tertiary" id="btn-regenerate-webhook">Regenerar Link</button>
                     </div>
                     <div class="integration-card">
+                        <h3>Chave Secreta de Postback</h3>
+                        <p>Insira abaixo a chave secreta utilizada para validar os postbacks de qualquer plataforma de vendas (Hotmart, Kiwify, etc.).</p>
+                        <div class="webhook-url-container">
+                            <input type="text" id="input-postback-secret" placeholder="Sua chave secreta">
+                            <button class="btn-primary" id="btn-save-postback-secret">Salvar</button>
+                        </div>
+                    </div>
+                    <div class="integration-card">
                         <h3>Histórico de Integrações</h3>
                         <div class="table-wrapper">
                             <table id="integration-history-table">

--- a/public/script.js
+++ b/public/script.js
@@ -51,6 +51,8 @@ const authFetch = (url, options = {}) => {
     const webhookUrlDisplayEl = document.getElementById('webhook-url-display');
     const btnCopyWebhookEl = document.getElementById('btn-copy-webhook');
     const btnRegenerateWebhookEl = document.getElementById('btn-regenerate-webhook');
+    const inputPostbackSecretEl = document.getElementById('input-postback-secret');
+    const btnSavePostbackSecretEl = document.getElementById('btn-save-postback-secret');
     const logoutBtnEl = document.getElementById('logout-btn');
     const modalConfirmacaoEl = document.getElementById('modal-confirmacao');
     const modalConfirmacaoTextoEl = document.getElementById('modal-confirmacao-texto');
@@ -419,6 +421,7 @@ const authFetch = (url, options = {}) => {
             const baseUrl = `${window.location.protocol}//${window.location.host}`;
             const webhookUrl = `${baseUrl}/api/postback?key=${data.apiKey}`;
             webhookUrlDisplayEl.textContent = webhookUrl;
+            if (inputPostbackSecretEl) inputPostbackSecretEl.value = data.settings && data.settings.postback_secret ? data.settings.postback_secret : '';
         } catch (error) {
             webhookUrlDisplayEl.textContent = "Erro ao carregar o link.";
             showNotification(error.message, 'error');
@@ -656,6 +659,24 @@ const authFetch = (url, options = {}) => {
                     showNotification(error.message, 'error');
                 }
             });
+        });
+    }
+
+    if (btnSavePostbackSecretEl) {
+        btnSavePostbackSecretEl.addEventListener('click', async () => {
+            const secretValue = inputPostbackSecretEl ? inputPostbackSecretEl.value.trim() : '';
+            try {
+                const resp = await authFetch('/api/integrations/settings', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ postback_secret: secretValue })
+                });
+                const data = await resp.json();
+                if (!resp.ok) throw new Error(data.error || 'Falha ao salvar.');
+                showNotification(data.message || 'Configurações atualizadas', 'success');
+            } catch (err) {
+                showNotification(err.message, 'error');
+            }
         });
     }
 

--- a/public/style.css
+++ b/public/style.css
@@ -237,6 +237,7 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 .btn-secondary:hover { background-color: var(--hover-bg); }
 .btn-tertiary { background: none; border: none; color: var(--primary-color); font-weight: 600; cursor: pointer; }
 .btn-tertiary:hover { text-decoration: underline; }
+.integration-card input[type="text"] { flex-grow: 1; padding: 12px; border: 1px solid var(--border-color); border-radius: 8px; }
 .table-wrapper { width: 100%; border: 1px solid var(--border-color); border-radius: 8px; overflow: hidden; }
 #integration-history-table { width: 100%; border-collapse: collapse; }
 #integration-history-table th, #integration-history-table td { padding: 12px 15px; text-align: left; border-bottom: 1px solid var(--border-color); }


### PR DESCRIPTION
## Summary
- add postback secret field to integrations page
- load saved secret and persist via new UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c002a823c83218bbc17d653202b2b