### PR TITLE
Adicionar pagina de planos e upgrade

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
                 <li><button class="nav-btn" data-view="integrations-view" title="Integrações"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.72"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.72"></path></svg></button></li>
                 <li><button class="nav-btn" data-view="reports-view" title="Relatórios"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"></path><path d="M18.7 8a6 6 0 0 0-6-6H3.3"></path><path d="M7 12h5"></path><path d="M7 16h9"></path></svg></button></li>
                 <li><button class="nav-btn" data-view="logs-view" title="Histórico"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v18H3z"></path><path d="M8 6h8"></path><path d="M8 10h8"></path><path d="M8 14h8"></path></svg></button></li>
+                <li><button class="nav-btn" data-view="plans-view" title="Planos"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"></rect><line x1="1" y1="10" x2="23" y2="10"></line></svg></button></li>
             </ul>
             <ul>
                 <li><button class="nav-btn" data-view="settings-view" title="Configurações"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06-.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg></button></li>
@@ -318,6 +319,17 @@
                     </div>
                 </div>
             </div>
+            <div id="plans-view" class="view-container hidden">
+                <div class="page-container">
+                    <header class="page-header">
+                        <div>
+                            <h1>Planos e Assinatura</h1>
+                            <p>Escolha um plano que atenda suas necessidades.</p>
+                        </div>
+                    </header>
+                    <div id="plans-list" class="plans-list"></div>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -330,6 +342,15 @@
             <div class="modal-acoes">
                 <button type="button" id="btn-confirmacao-cancelar" class="btn-cancelar">Cancelar</button>
                 <button type="button" id="btn-confirmacao-confirmar" class="btn-salvar">Confirmar</button>
+            </div>
+        </div>
+    </div>
+    <div id="modal-upgrade" class="modal-overlay">
+        <div class="modal-content">
+            <h3>Limite Atingido</h3>
+            <p>Você atingiu o limite do seu plano gratuito. Para continuar, por favor, faça o upgrade.</p>
+            <div class="modal-acoes">
+                <button type="button" id="btn-upgrade-plans" class="btn-salvar">Ver Planos</button>
             </div>
         </div>
     </div>

--- a/public/style.css
+++ b/public/style.css
@@ -394,3 +394,12 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     border-radius: 4px;
     cursor: pointer;
 }
+
+/* =================================
+   Planos
+   ================================= */
+.plans-list { display: flex; flex-wrap: wrap; gap: 20px; }
+.plan-card { background: #fff; border: 1px solid var(--border-color); border-radius: 12px; padding: 20px; flex: 1 1 250px; text-align: center; display: flex; flex-direction: column; gap: 10px; }
+.plan-card h3 { margin: 0; font-size: 1.25rem; }
+.plan-card p { margin: 0; color: var(--text-secondary); }
+.plan-card button { margin-top: auto; }

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 const userService = require('../services/userService');
+const subscriptionService = require('../services/subscriptionService');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
@@ -11,6 +12,7 @@ exports.register = async (req, res) => {
         const existing = await userService.findUserByEmail(req.db, email);
         if (existing) return res.status(409).json({ error: 'Usuário já existe.' });
         const user = await userService.createUser(req.db, email, password);
+        await subscriptionService.createSubscription(req.db, user.id, 1);
         res.status(201).json({ id: user.id, email: user.email, apiKey: user.api_key });
     } catch (err) {
         res.status(500).json({ error: 'Falha ao registrar usuário.' });


### PR DESCRIPTION
## Summary
- atribuir plano gratuito no registro
- criar página de planos e assinatura
- incluir modal informando o limite do plano gratuito
- permitir assinatura de plano pago via Stripe

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c1613d7ec8321bba768b60dbda2f8