### PR TITLE
Revamp usage calculation and UI billing history

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,12 +27,11 @@
         </nav>
         
         <div class="content-wrapper">
-            <div id="plan-status" class="plan-info"></div>
             <div id="chat-view" class="view-container">
                 <div class="app-layout">
                     <aside class="sidebar">
                         <header class="sidebar-header">
-                            <h2>Conversas</h2>
+                            <div id="plan-status" class="plan-info"></div>
                             <button id="btn-adicionar-novo" class="btn-icon" title="Adicionar Novo Pedido">+</button>
                         </header>
                         <div id="status-whatsapp" class="status-indicator disconnected">
@@ -308,14 +307,14 @@
                 <div class="page-container">
                     <header class="page-header">
                         <div>
-                            <h1>Histórico de Uso</h1>
-                            <p>Registros das ações realizadas.</p>
+                            <h1>Histórico de Faturamento</h1>
+                            <p>Pedidos contabilizados neste ciclo.</p>
                         </div>
                     </header>
                     <div class="table-wrapper">
-                        <table id="logs-table">
-                            <thead><tr><th>Data</th><th>Ação</th><th>Detalhe</th></tr></thead>
-                            <tbody id="logs-table-body"></tbody>
+                        <table id="billing-table">
+                            <thead><tr><th>Data</th><th>Cliente</th><th>Código</th></tr></thead>
+                            <tbody id="billing-table-body"></tbody>
                         </table>
                     </div>
                 </div>

--- a/public/script.js
+++ b/public/script.js
@@ -71,7 +71,7 @@ const authFetch = async (url, options = {}) => {
     const ordersDeliveredCardEl = document.getElementById('orders-delivered-card');
     const newContactsChartCanvas = document.getElementById('new-contacts-chart');
     const statusPieChartCanvas = document.getElementById('status-pie-chart');
-    const logsTableBodyEl = document.getElementById('logs-table-body');
+    const billingTableBodyEl = document.getElementById('billing-table-body');
     const toggleCreateContactEl = document.getElementById('toggle-create-contact');
     const toggleCreateContactLabelEl = document.getElementById('toggle-create-contact-label');
     const plansListEl = document.getElementById('plans-list');
@@ -165,7 +165,7 @@ const authFetch = async (url, options = {}) => {
         if (viewId === 'integrations-view') loadIntegrationInfo();
         if (viewId === 'settings-view') loadUserSettings();
         if (viewId === 'reports-view') loadReportData();
-        if (viewId === 'logs-view') loadLogs();
+        if (viewId === 'logs-view') loadBillingHistory();
         if (viewId === 'plans-view') loadPlans();
     }
 
@@ -573,25 +573,25 @@ const authFetch = async (url, options = {}) => {
         }
     }
 
-    async function loadLogs() {
-        if (!logsTableBodyEl) return;
-        logsTableBodyEl.innerHTML = '<tr><td colspan="3">A carregar...</td></tr>';
+    async function loadBillingHistory() {
+        if (!billingTableBodyEl) return;
+        billingTableBodyEl.innerHTML = '<tr><td colspan="3">A carregar...</td></tr>';
         try {
-            const resp = await authFetch('/api/logs');
-            if (!resp.ok) throw new Error('Falha ao carregar logs.');
-            const { data } = await resp.json();
-            logsTableBodyEl.innerHTML = '';
-            if (!data || data.length === 0) {
-                logsTableBodyEl.innerHTML = '<tr><td colspan="3">Sem registros.</td></tr>';
+            const resp = await authFetch('/api/billing/history');
+            if (!resp.ok) throw new Error('Falha ao carregar histórico.');
+            const { pedidos } = await resp.json();
+            billingTableBodyEl.innerHTML = '';
+            if (!pedidos || pedidos.length === 0) {
+                billingTableBodyEl.innerHTML = '<tr><td colspan="3">Nenhum pedido contabilizado.</td></tr>';
                 return;
             }
-            data.forEach(log => {
+            pedidos.forEach(p => {
                 const tr = document.createElement('tr');
-                tr.innerHTML = `<td>${new Date(log.data_criacao).toLocaleString()}</td><td>${log.acao}</td><td>${log.detalhe || ''}</td>`;
-                logsTableBodyEl.appendChild(tr);
+                tr.innerHTML = `<td>${new Date(p.dataCriacao).toLocaleDateString()}</td><td>${p.nome}</td><td>${p.codigoRastreio}</td>`;
+                billingTableBodyEl.appendChild(tr);
             });
         } catch (err) {
-            console.error('Erro ao carregar logs:', err);
+            console.error('Erro ao carregar histórico de faturamento:', err);
         }
     }
 

--- a/public/style.css
+++ b/public/style.css
@@ -404,3 +404,4 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 .plan-card p { margin: 0; color: var(--text-secondary); }
 .plan-card button { margin-top: auto; }
 .plan-info { background: #fff; border: 1px solid var(--border-color); border-radius: 12px; padding: 15px; margin: 20px; text-align: center; }
+.sidebar-header .plan-info { margin: 0; flex: 1; }

--- a/server.js
+++ b/server.js
@@ -224,6 +224,8 @@ const startApp = async () => {
             try {
                 const sub = await subscriptionService.getUserSubscription(req.db, req.user.id);
                 if (!sub) return res.status(404).json({ error: 'Nenhum plano encontrado' });
+                const usage = await subscriptionService.calculateUsage(req.db, sub);
+                sub.usage = usage;
                 res.json({ subscription: sub });
             } catch (err) {
                 console.error('Erro ao obter assinatura:', err);
@@ -271,6 +273,7 @@ const startApp = async () => {
 
         // Rotas de Relatórios
         app.get('/api/reports/summary', planCheck, reportsController.getReportSummary);
+        app.get('/api/billing/history', planCheck, reportsController.getBillingHistory);
 
         // Rotas de Logs
         app.get('/api/logs', planCheck, logsController.listarLogs);

--- a/src/controllers/envioController.js
+++ b/src/controllers/envioController.js
@@ -94,7 +94,7 @@ async function enviarMensagensComRegras(db) {
 
             if (mensagemParaEnviar && novoStatusDaMensagem) {
                 await whatsappService.enviarMensagem(telefone, mensagemParaEnviar);
-                await pedidoService.addMensagemHistorico(db, id, mensagemParaEnviar, novoStatusDaMensagem, 'bot');
+                await pedidoService.addMensagemHistorico(db, id, mensagemParaEnviar, novoStatusDaMensagem, 'bot', pedido.cliente_id);
                 await pedidoService.updateCamposPedido(db, id, { mensagemUltimoStatus: novoStatusDaMensagem });
                 console.log(`✅ Mensagem automática de '${novoStatusDaMensagem}' enviada para ${nome}.`);
 

--- a/src/controllers/integrationsController.js
+++ b/src/controllers/integrationsController.js
@@ -37,9 +37,6 @@ exports.receberPostback = async (req, res) => {
         const pedidoCriado = await pedidoService.criarPedido(db, novoPedido, req.venomClient, clienteId);
 
         req.broadcast({ type: 'novo_contato', pedido: pedidoCriado });
-        if (req.subscription) {
-            await subscriptionService.incrementUsage(db, req.subscription.id);
-        }
         res.status(201).json({ message: "Pedido recebido e criado com sucesso!", data: pedidoCriado });
 
     } catch (error) {

--- a/src/controllers/pedidosController.js
+++ b/src/controllers/pedidosController.js
@@ -85,9 +85,6 @@ exports.criarPedido = async (req, res) => {
 
         await logService.addLog(db, clienteId, 'pedido_criado', JSON.stringify({ pedidoId: pedidoCriado.id }));
 
-        if (req.subscription) {
-            await subscriptionService.incrementUsage(db, req.subscription.id);
-        }
 
         res.status(201).json({
             message: "Pedido criado com sucesso!",
@@ -175,10 +172,6 @@ exports.enviarMensagemManual = async (req, res) => {
         await pedidoService.addMensagemHistorico(db, id, mensagem, 'manual', 'bot', clienteId);
 
         await logService.addLog(db, clienteId, 'mensagem_manual', JSON.stringify({ pedidoId: id }));
-
-        if (req.subscription) {
-            await subscriptionService.incrementUsage(db, req.subscription.id);
-        }
         
         // MUDANÇA: Notifica todos os painéis abertos sobre a nova mensagem
         broadcast({ type: 'nova_mensagem', pedidoId: parseInt(id) });

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -1,5 +1,8 @@
 // src/controllers/reportsController.js
 
+const subscriptionService = require('../services/subscriptionService');
+const pedidoService = require('../services/pedidoService');
+
 // Função auxiliar para executar consultas SQL e retornar uma Promise
 const runQuery = (dbInstance, sql, params = []) => {
     return new Promise((resolve, reject) => {
@@ -42,6 +45,30 @@ exports.getReportSummary = async (req, res) => {
     } catch (error) {
         console.error("ERRO DETALHADO AO GERAR RELATÓRIO:", error);
         res.status(500).json({ error: "Falha ao gerar o resumo do relatório." });
+    }
+};
+
+exports.getBillingHistory = async (req, res) => {
+    try {
+        const db = req.db;
+        const userId = req.user.id;
+        const sub = await subscriptionService.getUserSubscription(db, userId);
+        if (!sub) return res.status(404).json({ error: 'Nenhum plano encontrado' });
+
+        const usage = await subscriptionService.calculateUsage(db, sub);
+        const end = require('moment')(sub.renewal_date);
+        const start = end.clone().subtract(1, 'month');
+        const pedidos = await pedidoService.getPedidosComCodigoAtivo(
+            db,
+            userId,
+            start.format('YYYY-MM-DD'),
+            end.format('YYYY-MM-DD')
+        );
+
+        res.json({ usage, pedidos });
+    } catch (err) {
+        console.error('Erro ao obter histórico de faturamento:', err);
+        res.status(500).json({ error: 'Falha ao buscar histórico de faturamento' });
     }
 };
 

--- a/src/services/subscriptionService.js
+++ b/src/services/subscriptionService.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const pedidoService = require('./pedidoService');
 
 function getUserSubscription(db, userId) {
     return new Promise((resolve, reject) => {
@@ -72,5 +73,26 @@ function updateSubscriptionStatus(db, userId, status) {
     });
 }
 
-module.exports = { getUserSubscription, incrementUsage, resetUsageIfNeeded, createSubscription, updateUserPlan, updateSubscriptionStatus };
+async function calculateUsage(db, sub) {
+    if (!sub.renewal_date) return 0;
+    const end = moment(sub.renewal_date);
+    const start = end.clone().subtract(1, 'month');
+    const pedidos = await pedidoService.getPedidosComCodigoAtivo(
+        db,
+        sub.user_id,
+        start.format('YYYY-MM-DD'),
+        end.format('YYYY-MM-DD')
+    );
+    return pedidos.length;
+}
+
+module.exports = {
+    getUserSubscription,
+    incrementUsage,
+    resetUsageIfNeeded,
+    createSubscription,
+    updateUserPlan,
+    updateSubscriptionStatus,
+    calculateUsage,
+};
 


### PR DESCRIPTION
## Summary
- count active tracking codes during billing cycle instead of incrementing usage
- show billing history and plan info in sidebar
- fix message history by filtering client id and saving it on automation messages
- expose usage details via new API route
- update frontend to display billing history

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c97e3dbe88321aba03b86882aa465