### PR TITLE
Add package movement tracking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -139,6 +139,9 @@
                         <strong class="variable-highlight" data-value="{{data_postagem}}"><span>{{data_postagem}}</span></strong>
                         <strong class="variable-highlight" data-value="{{ultima_atualizacao}}"><span>{{ultima_atualizacao}}</span></strong>
                         <strong class="variable-highlight" data-value="{{mensagem_ultimo_status}}"><span>{{mensagem_ultimo_status}}</span></strong>
+                        <strong class="variable-highlight" data-value="{{cidade_etapa_origem}}"><span>{{cidade_etapa_origem}}</span></strong>
+                        <strong class="variable-highlight" data-value="{{cidade_etapa_destino}}"><span>{{cidade_etapa_destino}}</span></strong>
+                        <strong class="variable-highlight" data-value="{{status_detalhado_correios}}"><span>{{status_detalhado_correios}}</span></strong>
                     </div>
                 </div>
 

--- a/src/controllers/envioController.js
+++ b/src/controllers/envioController.js
@@ -48,6 +48,9 @@ function personalizarMensagem(mensagem, pedido) {
         .replace(/{{status_atual}}/g, pedido.statusInterno || 'Status não disponível')
         .replace(/{{data_atualizacao}}/g, dataFormatada || 'Data não disponível')
         .replace(/{{ultima_localizacao}}/g, pedido.ultimaLocalizacao || 'Localização não disponível')
+        .replace(/{{cidade_etapa_origem}}/g, pedido.origemUltimaMovimentacao || '')
+        .replace(/{{cidade_etapa_destino}}/g, pedido.destinoUltimaMovimentacao || '')
+        .replace(/{{status_detalhado_correios}}/g, pedido.descricaoUltimoEvento || '')
         .replace(/{{link_rastreio}}/g, linkRastreio);
 }
 

--- a/src/controllers/rastreamentoController.js
+++ b/src/controllers/rastreamentoController.js
@@ -38,6 +38,9 @@ async function verificarRastreios(db) {
                     statusInterno: novoStatus,
                     ultimaLocalizacao: dadosRastreio.ultimaLocalizacao,
                     ultimaAtualizacao: dadosRastreio.ultimaAtualizacao,
+                    origemUltimaMovimentacao: dadosRastreio.origemUltimaMovimentacao,
+                    destinoUltimaMovimentacao: dadosRastreio.destinoUltimaMovimentacao,
+                    descricaoUltimoEvento: dadosRastreio.descricaoUltimoEvento,
                 };
                 
                 await pedidoService.updateCamposPedido(db, pedido.id, dadosParaAtualizar);

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -26,6 +26,9 @@ const initDb = () => {
                         statusInterno TEXT,
                         ultimaAtualizacao TEXT,
                         ultimaLocalizacao TEXT,
+                        origemUltimaMovimentacao TEXT,
+                        destinoUltimaMovimentacao TEXT,
+                        descricaoUltimoEvento TEXT,
                         mensagemUltimoStatus TEXT,
                         fotoPerfilUrl TEXT,
                         dataCriacao TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -255,6 +258,17 @@ const initDb = () => {
                     db.run("ALTER TABLE automacoes ADD COLUMN cliente_id INTEGER", [], (e) => {
                         if (e && !e.message.includes('duplicate')) return reject(e);
                         db.run("UPDATE automacoes SET cliente_id = 1 WHERE cliente_id IS NULL");
+                    });
+
+                    // Novas colunas para detalhes de rastreio
+                    db.run("ALTER TABLE pedidos ADD COLUMN origemUltimaMovimentacao TEXT", [], (e) => {
+                        if (e && !e.message.includes('duplicate')) return reject(e);
+                    });
+                    db.run("ALTER TABLE pedidos ADD COLUMN destinoUltimaMovimentacao TEXT", [], (e) => {
+                        if (e && !e.message.includes('duplicate')) return reject(e);
+                    });
+                    db.run("ALTER TABLE pedidos ADD COLUMN descricaoUltimoEvento TEXT", [], (e) => {
+                        if (e && !e.message.includes('duplicate')) return reject(e);
                     });
 
                     // Bloco movido para dentro da criação da tabela 'users'

--- a/src/services/rastreamentoService.js
+++ b/src/services/rastreamentoService.js
@@ -43,11 +43,27 @@ async function rastrearCodigo(codigo, apiKey = null) {
         }
 
         const ultimoEvento = eventos[0]; // O evento mais recente
-        
+
+        const descricaoCompleta = ultimoEvento.description || ultimoEvento.descricao || ultimoEvento.descricaoFrontEnd || '';
+
+        let origem = null;
+        let destino = null;
+        if (descricaoCompleta) {
+            const regex = /de\s+(.*?)\s+para\s+(.*)/i;
+            const match = descricaoCompleta.match(regex);
+            if (match) {
+                origem = match[1].trim();
+                destino = match[2].trim();
+            }
+        }
+
         return {
             statusInterno: ultimoEvento.status || ultimoEvento.descricaoFrontEnd || 'Desconhecido',
             ultimaLocalizacao: ultimoEvento.location || ultimoEvento.unidade?.endereco?.cidade || '-',
             ultimaAtualizacao: `${ultimoEvento.date || ''} ${ultimoEvento.time || ''}`.trim() || ultimoEvento.dtHrCriado?.date || '-',
+            origemUltimaMovimentacao: origem,
+            destinoUltimaMovimentacao: destino,
+            descricaoUltimoEvento: descricaoCompleta,
             eventos: eventos
         };
 


### PR DESCRIPTION
## Summary
- parse Correios event description to extract origin/destination
- store movement details in database
- expose variables in message templates

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d9c1aa0888321b7d62835d5a410f7