### PR TITLE
Simplify automation variables

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -134,17 +134,11 @@
                         <svg class="accordion-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
                     </button>
                     <div class="accordion-content">
-                        <strong class="variable-highlight" data-value="{{status_interno}}"><span>{{status_interno}}</span></strong>
                         <strong class="variable-highlight" data-value="{{status_rastreio}}" data-tooltip="Mostra o status resumido do rastreamento (Ex: 'A caminho', 'Entregue', 'Postado')."><span>{{status_rastreio}}</span></strong>
-                        <strong class="variable-highlight" data-value="{{ultima_localizacao}}"><span>{{ultima_localizacao}}</span></strong>
-                        <strong class="variable-highlight" data-value="{{data_postagem}}"><span>{{data_postagem}}</span></strong>
                         <strong class="variable-highlight" data-value="{{data_postagem_formatada}}" data-tooltip="A data em que o pedido foi postado, no formato dd/mm/aaaa."><span>{{data_postagem_formatada}}</span></strong>
-                        <strong class="variable-highlight" data-value="{{ultima_atualizacao}}"><span>{{ultima_atualizacao}}</span></strong>
                         <strong class="variable-highlight" data-value="{{data_atualizacao_formatada}}" data-tooltip="A data e a hora da última atualização do rastreio, no formato dd/mm/aaaa HH:mm."><span>{{data_atualizacao_formatada}}</span></strong>
-                        <strong class="variable-highlight" data-value="{{mensagem_ultimo_status}}"><span>{{mensagem_ultimo_status}}</span></strong>
                         <strong class="variable-highlight" data-value="{{cidade_etapa_origem}}" data-tooltip="Mostra a cidade de ONDE o pacote saiu na última movimentação registrada pelos Correios."><span>{{cidade_etapa_origem}}</span></strong>
                         <strong class="variable-highlight" data-value="{{cidade_etapa_destino}}" data-tooltip="Mostra a cidade para ONDE o pacote está indo na última movimentação registrada."><span>{{cidade_etapa_destino}}</span></strong>
-                        <strong class="variable-highlight" data-value="{{status_detalhado_correios}}" data-tooltip="Insere o texto completo e original do último status informado pelos Correios. (Ex: 'Objeto em trânsito - de Unidade de Tratamento em SAO PAULO para Unidade de Distribuição em RECIFE')."><span>{{status_detalhado_correios}}</span></strong>
                         <strong class="variable-highlight" data-value="{{link_rastreio}}" data-tooltip="Insere o link completo e clicável para a página de rastreamento dos Correios."><span>{{link_rastreio}}</span></strong>
                     </div>
                 </div>

--- a/public/script.js
+++ b/public/script.js
@@ -84,7 +84,6 @@ const planStatusEl = document.getElementById('plan-status');
         '{{status_rastreio}}': "Mostra o status resumido do rastreamento (Ex: 'A caminho', 'Entregue', 'Postado').",
         '{{cidade_etapa_origem}}': 'Mostra a cidade de ONDE o pacote saiu na última movimentação registrada pelos Correios.',
         '{{cidade_etapa_destino}}': 'Mostra a cidade para ONDE o pacote está indo na última movimentação registrada.',
-        '{{status_detalhado_correios}}': 'Insere o texto completo e original do último status informado pelos Correios. (Ex: \"Objeto em trânsito - de Unidade de Tratamento em SAO PAULO para Unidade de Distribuição em RECIFE\").',
         '{{data_postagem_formatada}}': 'A data em que o pedido foi postado, no formato dd/mm/aaaa.',
         '{{data_atualizacao_formatada}}': 'A data e a hora da última atualização do rastreio, no formato dd/mm/aaaa HH:mm.'
     };

--- a/src/controllers/envioController.js
+++ b/src/controllers/envioController.js
@@ -47,10 +47,8 @@ function personalizarMensagem(mensagem, pedido) {
         .replace(/{{codigo_rastreio}}/g, pedido.codigoRastreio || '')
         .replace(/{{status_atual}}/g, pedido.statusInterno || 'Status não disponível')
         .replace(/{{data_atualizacao}}/g, dataFormatada || 'Data não disponível')
-        .replace(/{{ultima_localizacao}}/g, pedido.ultimaLocalizacao || 'Localização não disponível')
         .replace(/{{cidade_etapa_origem}}/g, pedido.origemUltimaMovimentacao || '')
         .replace(/{{cidade_etapa_destino}}/g, pedido.destinoUltimaMovimentacao || '')
-        .replace(/{{status_detalhado_correios}}/g, pedido.descricaoUltimoEvento || '')
         .replace(/{{link_rastreio}}/g, linkRastreio);
 }
 


### PR DESCRIPTION
## Summary
- streamline the Rastreio variable list in the interface
- drop unused tracking variables from tooltip hints
- stop replacing removed variables in message personalization

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685da8a7fb0c8321a1db56d201da7ba8