### PR TITLE
Add pagination for integration history

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -230,13 +230,10 @@
                         <div class="table-wrapper">
                             <table id="integration-history-table">
                                 <thead><tr><th>Data</th><th>Nome do Cliente</th><th>Produto</th><th>Status</th></tr></thead>
-                                <tbody>
-                                    <tr><td>18/06/2025 21:30</td><td>Maria Silva</td><td>Produto Exemplo A</td><td><span class="status-badge success">Recebido</span></td></tr>
-                                    <tr><td>18/06/2025 19:45</td><td>João Pereira</td><td>Produto Exemplo B</td><td><span class="status-badge success">Recebido</span></td></tr>
-                                    <tr><td>17/06/2025 15:10</td><td>Ana Costa</td><td>-</td><td><span class="status-badge error">Falhou</span></td></tr>
-                                </tbody>
+                                <tbody id="integration-history-body"></tbody>
                             </table>
                         </div>
+                        <div id="integration-pagination" class="pagination"></div>
                     </div>
                 </div>
             </div>

--- a/public/style.css
+++ b/public/style.css
@@ -456,3 +456,9 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 .sidebar-header .plan-info { margin: 0; flex: 1; }
 .plan-progress { margin-top: 6px; height: 6px; background-color: var(--hover-bg); border-radius: 4px; overflow: hidden; }
 .plan-progress-bar { height: 100%; background-color: var(--primary-color); width: 0%; }
+
+/* Pagination */
+.pagination { display: flex; justify-content: center; gap: 6px; margin-top: 10px; }
+.pagination button { padding: 4px 8px; border: 1px solid var(--border-color); background: #fff; border-radius: 4px; cursor: pointer; }
+.pagination button.active { background: var(--primary-color); color: #fff; }
+.pagination button:disabled { opacity: 0.5; cursor: default; }

--- a/server.js
+++ b/server.js
@@ -284,6 +284,7 @@ const startApp = async () => {
         app.get('/api/integrations/info', planCheck, integrationsController.getIntegrationInfo);
         app.post('/api/integrations/regenerate', planCheck, integrationsController.regenerateApiKey);
         app.put('/api/integrations/settings', planCheck, integrationsController.updateIntegrationSettings);
+        app.get('/api/integrations/history', planCheck, integrationsController.listarHistorico);
 
         // Rotas de Configurações de Usuário
         app.get('/api/settings/contact-creation', planCheck, settingsController.getContactCreationSetting);

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -69,6 +69,21 @@ const initDb = () => {
                     if (err) return reject(err);
                 });
 
+                // Tabela de Histórico de Integrações
+                db.run(`
+                    CREATE TABLE IF NOT EXISTS integration_history (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        user_id INTEGER,
+                        client_name TEXT,
+                        client_cell TEXT,
+                        product_name TEXT,
+                        status TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    )
+                `, (err) => {
+                    if (err) return reject(err);
+                });
+
                 // Tabela de Automações com chave composta (cliente + gatilho)
                 db.run(`
                     CREATE TABLE IF NOT EXISTS automacoes (

--- a/src/services/integrationHistoryService.js
+++ b/src/services/integrationHistoryService.js
@@ -1,0 +1,30 @@
+function addEntry(db, userId, clientName, clientCell, productName, status) {
+    return new Promise((resolve, reject) => {
+        const sql = `INSERT INTO integration_history (user_id, client_name, client_cell, product_name, status) VALUES (?, ?, ?, ?, ?)`;
+        db.run(sql, [userId, clientName, clientCell, productName, status], function(err) {
+            if (err) return reject(err);
+            resolve({ id: this.lastID });
+        });
+    });
+}
+
+function getPaginated(db, userId, limit, offset) {
+    return new Promise((resolve, reject) => {
+        const sql = `SELECT * FROM integration_history WHERE user_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`;
+        db.all(sql, [userId, limit, offset], (err, rows) => {
+            if (err) return reject(err);
+            resolve(rows);
+        });
+    });
+}
+
+function countAll(db, userId) {
+    return new Promise((resolve, reject) => {
+        db.get('SELECT COUNT(*) as total FROM integration_history WHERE user_id = ?', [userId], (err, row) => {
+            if (err) return reject(err);
+            resolve(row.total || 0);
+        });
+    });
+}
+
+module.exports = { addEntry, getPaginated, countAll };


### PR DESCRIPTION
## Summary
- create `integration_history` table and service
- record integration events
- add API endpoint `/api/integrations/history`
- implement pagination UI for integration history

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685dac23284083218409790a8b79c2e7