### PR TITLE
Atualiza relatórios com novas métricas

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -281,16 +281,32 @@
                     </header>
                     <div class="report-cards-grid">
                         <div class="report-card">
-                            <h4>Total de Contatos</h4>
-                            <p id="total-contacts-card">0</p>
+                            <div class="report-card-icon">🚚</div>
+                            <div>
+                                <h4>Pedidos em Trânsito</h4>
+                                <p id="orders-in-transit-card">0</p>
+                            </div>
                         </div>
                         <div class="report-card">
-                            <h4>Mensagens Enviadas</h4>
-                            <p id="messages-sent-card">0</p>
+                            <div class="report-card-icon">⏳</div>
+                            <div>
+                                <h4>Tempo Médio de Entrega</h4>
+                                <p id="average-delivery-time-card">0</p>
+                            </div>
                         </div>
-                        <div class="report-card">
-                            <h4>Pedidos Entregues</h4>
-                            <p id="orders-delivered-card">0</p>
+                        <div class="report-card alert-card">
+                            <div class="report-card-icon">⚠️</div>
+                            <div>
+                                <h4>Pedidos com Alerta</h4>
+                                <p id="alert-orders-card">0</p>
+                            </div>
+                        </div>
+                        <div class="report-card success-card">
+                            <div class="report-card-icon">✅</div>
+                            <div>
+                                <h4>Taxa de Entrega</h4>
+                                <p id="delivery-rate-card">0%</p>
+                            </div>
                         </div>
                     </div>
                     <div class="charts-grid">

--- a/public/script.js
+++ b/public/script.js
@@ -66,9 +66,10 @@ const authFetch = async (url, options = {}) => {
     const modalConfirmacaoTextoEl = document.getElementById('modal-confirmacao-texto');
     const btnConfirmacaoCancelarEl = document.getElementById('btn-confirmacao-cancelar');
     const btnConfirmacaoConfirmarEl = document.getElementById('btn-confirmacao-confirmar');
-    const totalContactsCardEl = document.getElementById('total-contacts-card');
-    const messagesSentCardEl = document.getElementById('messages-sent-card');
-    const ordersDeliveredCardEl = document.getElementById('orders-delivered-card');
+    const ordersInTransitCardEl = document.getElementById('orders-in-transit-card');
+    const averageDeliveryTimeCardEl = document.getElementById('average-delivery-time-card');
+    const alertOrdersCardEl = document.getElementById('alert-orders-card');
+    const deliveryRateCardEl = document.getElementById('delivery-rate-card');
     const newContactsChartCanvas = document.getElementById('new-contacts-chart');
     const statusPieChartCanvas = document.getElementById('status-pie-chart');
     const billingTableBodyEl = document.getElementById('billing-table-body');
@@ -580,35 +581,46 @@ const planStatusEl = document.getElementById('plan-status');
         });
     }
 
+
     function createStatusChart(data) {
         if (!statusPieChartCanvas || typeof Chart === 'undefined') return;
         if (statusChart) statusChart.destroy();
         const labels = data.map(item => item.statusInterno ? (item.statusInterno.charAt(0).toUpperCase() + item.statusInterno.slice(1)) : 'Não definido');
         const counts = data.map(item => item.count);
+        const colorMap = {
+            entregue: 'rgba(34,197,94,0.7)',
+            pedido_atrasado: 'rgba(234,179,8,0.7)',
+            pedido_devolvido: 'rgba(239,68,68,0.7)'
+        };
+        const backgroundColors = data.map(item => colorMap[item.statusInterno] || 'rgba(59,130,246,0.7)');
         statusChart = new Chart(statusPieChartCanvas, {
-            type: 'doughnut',
+            type: 'bar',
             data: {
                 labels: labels,
                 datasets: [{
                     label: 'Status dos Pedidos',
                     data: counts,
-                    backgroundColor: ['rgba(249, 115, 22, 0.7)', 'rgba(22, 163, 74, 0.7)', 'rgba(239, 68, 68, 0.7)', 'rgba(107, 114, 128, 0.7)', 'rgba(245, 158, 11, 0.7)'],
-                    borderColor: '#fff',
-                    borderWidth: 2
+                    backgroundColor: backgroundColors,
+                    borderWidth: 1
                 }]
             },
-            options: { responsive: true, plugins: { legend: { position: 'top' } } }
+            options: {
+                responsive: true,
+                indexAxis: 'y',
+                plugins: { legend: { display: false } },
+                scales: { x: { beginAtZero: true } }
+            }
         });
     }
-
     async function loadReportData() {
         try {
             const response = await authFetch('/api/reports/summary');
             if (!response.ok) throw new Error('Falha ao carregar dados do relatório.');
             const data = await response.json();
-            if(totalContactsCardEl) totalContactsCardEl.textContent = data.totalContacts;
-            if(messagesSentCardEl) messagesSentCardEl.textContent = data.messagesSent;
-            if(ordersDeliveredCardEl) ordersDeliveredCardEl.textContent = data.ordersDelivered;
+            if(ordersInTransitCardEl) ordersInTransitCardEl.textContent = data.ordersInTransit;
+            if(averageDeliveryTimeCardEl) averageDeliveryTimeCardEl.textContent = data.averageDeliveryTime;
+            if(alertOrdersCardEl) alertOrdersCardEl.textContent = data.alertOrders;
+            if(deliveryRateCardEl) deliveryRateCardEl.textContent = data.deliveryRate + '%';
             createContactsChart(data.newContactsLast7Days);
             createStatusChart(data.statusDistribution);
         } catch (error) {

--- a/public/style.css
+++ b/public/style.css
@@ -305,9 +305,22 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
    12. PÁGINA DE RELATÓRIOS
    ================================= */
 .report-cards-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-bottom: 30px; }
-.report-card { background-color: #ffffff; padding: 20px; border-radius: 12px; border: 1px solid var(--border-color); }
-.report-card h4 { color: var(--text-secondary); font-size: 1rem; margin: 0 0 10px 0; }
-.report-card p { font-size: 2.25rem; font-weight: 700; color: var(--text-color); margin: 0; }
+.report-card {
+  background-color: #ffffff;
+  padding: 20px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.report-card-icon {
+  font-size: 2rem;
+}
+.report-card h4 { color: var(--text-secondary); font-size: 1rem; margin: 0; }
+.report-card p { font-size: 2rem; font-weight: 700; color: var(--text-color); margin: 0; }
+.alert-card { background-color: #fef3c7; border-color: #f59e0b; }
+.success-card { background-color: #ecfdf5; border-color: #10b981; }
 .charts-grid { display: grid; grid-template-columns: 2fr 1fr; gap: 20px; align-items: flex-start; }
 .chart-container { background-color: #ffffff; padding: 25px; border-radius: 12px; border: 1px solid var(--border-color); }
 .chart-container h3 { margin: 0 0 20px 0; text-align: center; font-size: 1.1rem; }


### PR DESCRIPTION
## Summary
- adicionar cards de métricas de rastreamento na página de relatórios
- atualizar estilo dos cards
- atualizar gráfico de status para barras horizontais
- calcular novas métricas no backend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685daea5dbc48321993f787435c155a7