### PR TITLE
Simplifica cabeçalho e reposiciona status

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,15 +30,8 @@
                 <div class="app-layout">
                     <aside class="sidebar">
                         <header class="sidebar-header">
-                            <div class="user-status">
-                                <span id="logged-user">Usuário</span>
-                                <div id="connection-status" class="connection-status disconnected">
-                                    <span class="status-dot"></span>
-                                    <span id="connection-status-text">Desconectado</span>
-                                </div>
-                                <button id="btn-adicionar-novo" class="btn-icon" title="Adicionar Novo Pedido">+</button>
-                            </div>
                             <div id="plan-status" class="plan-info"></div>
+                            <button id="btn-adicionar-novo" class="btn-icon" title="Adicionar Novo Pedido">+</button>
                         </header>
                         <div class="list-controls">
                             <div class="search-container">
@@ -49,6 +42,16 @@
                                 <button class="filter-btn active" data-filtro="todos">Todos</button>
                                 <button class="filter-btn" data-filtro="caminho">A Caminho</button>
                                 <button class="filter-btn" data-filtro="entregue">Entregue</button>
+                            </div>
+                        </div>
+                        <div id="connection-status" class="status-indicator disconnected">
+                            <span class="status-dot"></span>
+                            <div class="status-text">
+                                <span id="connection-status-text">Desconectado</span>
+                                <span id="status-bot-info"></span>
+                            </div>
+                            <div id="bot-avatar-container" class="hidden">
+                                <img id="bot-avatar-img" src="https://i.imgur.com/z28n3Nz.png" alt="Avatar do Bot">
                             </div>
                         </div>
                         <div class="contact-list" id="lista-contactos"></div>

--- a/public/script.js
+++ b/public/script.js
@@ -46,6 +46,9 @@ const authFetch = async (url, options = {}) => {
     const btnSalvarAutomacoesEl = document.getElementById('btn-salvar-automacoes');
     const connectionStatusEl = document.getElementById('connection-status');
     const connectionStatusTextEl = document.getElementById('connection-status-text');
+    const statusBotInfoEl = document.getElementById('status-bot-info');
+    const botAvatarImgEl = document.getElementById('bot-avatar-img');
+    const botAvatarContainerEl = document.getElementById('bot-avatar-container');
     const loggedUserEl = document.getElementById('logged-user');
     const qrCodeContainerEl = document.getElementById('qr-code-container');
     const btnConectarEl = document.getElementById('btn-conectar');
@@ -240,10 +243,18 @@ const planStatusEl = document.getElementById('plan-status');
         if (settingsConnectionStatusEl) settingsConnectionStatusEl.classList.add('hidden');
         if (qrCodeContainerEl) qrCodeContainerEl.innerHTML = '';
         if (connectionStatusEl) {
-            connectionStatusEl.className = 'connection-status';
+            connectionStatusEl.className = 'status-indicator';
             connectionStatusEl.classList.add(status.toLowerCase());
         }
         if (connectionStatusTextEl) connectionStatusTextEl.textContent = statusText;
+        if (statusBotInfoEl) statusBotInfoEl.textContent = '';
+        if (botAvatarImgEl) botAvatarImgEl.src = 'https://i.imgur.com/z28n3Nz.png';
+        if (botAvatarContainerEl) botAvatarContainerEl.classList.add('hidden');
+        if (status === 'CONNECTED' && data.botInfo) {
+            if (statusBotInfoEl) statusBotInfoEl.textContent = `${data.botInfo.nome} - ${data.botInfo.numero}`;
+            if (botAvatarImgEl && data.botInfo.fotoUrl) botAvatarImgEl.src = data.botInfo.fotoUrl;
+            if (botAvatarContainerEl) botAvatarContainerEl.classList.remove('hidden');
+        }
 
         if (status === 'QR_CODE' && data.qrCode) {
             if (settingsConnectionStatusEl) settingsConnectionStatusEl.classList.remove('hidden');
@@ -262,7 +273,6 @@ const planStatusEl = document.getElementById('plan-status');
             }
             if (settingsBotNameEl) settingsBotNameEl.textContent = data.botInfo.nome || 'Nome não encontrado';
             if (settingsBotNumberEl) settingsBotNumberEl.textContent = data.botInfo.numero;
-            if (connectionStatusTextEl) connectionStatusTextEl.textContent = 'Conectado';
         } else {
             if (settingsConnectionStatusEl) settingsConnectionStatusEl.classList.remove('hidden');
             if (settingsStatusTextEl) settingsStatusTextEl.textContent = statusText;

--- a/public/style.css
+++ b/public/style.css
@@ -145,8 +145,8 @@ body {
 .status-indicator.disconnected .status-dot { background-color: var(--error-color); }
 .status-indicator.connected .status-dot { background-color: var(--success-color); }
 .status-indicator.connecting .status-dot { background-color: #f59e0b; }
+#status-text-label, #connection-status-text { font-size: 1rem; font-weight: 600; }
 .status-text { display: flex; flex-direction: column; line-height: 1.3; }
-#status-text-label { font-size: 1rem; font-weight: 600; }
 #status-bot-info { font-size: 0.8rem; color: var(--text-secondary); }
 #bot-avatar-container { margin-left: auto; width: 40px; height: 40px; border-radius: 50%; overflow: hidden; flex-shrink: 0; border: 2px solid var(--border-color); }
 #bot-avatar-img { width: 100%; height: 100%; object-fit: cover; }


### PR DESCRIPTION
## Summary
- simplifica cabeçalho da sidebar deixando apenas o plano e o botão de adicionar
- coloca o status de conexão novamente abaixo da busca
- ajusta estilos e script para exibir nome, número e avatar do bot

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685dbe884ab88321a5852327a5a0c5d7