### PR TITLE
Fix admin plan check and add DB clean script

### DIFF
--- a/limpar-usuarios.js
+++ b/limpar-usuarios.js
@@ -1,0 +1,28 @@
+require('dotenv').config();
+const { initDb } = require('./src/database/database');
+
+(async () => {
+  const db = await initDb().catch(err => {
+    console.error('Erro ao conectar ao banco de dados:', err);
+    process.exit(1);
+  });
+
+  const run = (sql) => new Promise((resolve, reject) => {
+    db.run(sql, err => err ? reject(err) : resolve());
+  });
+
+  try {
+    await run('BEGIN TRANSACTION');
+    await run('DELETE FROM historico_mensagens');
+    await run('DELETE FROM pedidos');
+    await run('DELETE FROM subscriptions');
+    await run('DELETE FROM users');
+    await run('COMMIT');
+    console.log('✅ Banco de dados limpo com sucesso. Todos os usuários e dados relacionados foram apagados.');
+  } catch (err) {
+    await run('ROLLBACK').catch(() => {});
+    console.error('Erro ao limpar banco de dados:', err);
+  } finally {
+    db.close();
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "create-admin": "node criar-admin.js"
+    "create-admin": "node criar-admin.js",
+    "clean-users": "node limpar-usuarios.js"
   },
   "keywords": [],
   "author": "",

--- a/src/middleware/planCheck.js
+++ b/src/middleware/planCheck.js
@@ -1,6 +1,9 @@
 const subscriptionService = require('../services/subscriptionService');
 
 module.exports = async (req, res, next) => {
+    if (req.user && req.user.is_admin) {
+        return next();
+    }
     const userId = req.user && req.user.id;
     if (!userId) return res.status(401).json({ error: 'Usuário não autenticado' });
     try {


### PR DESCRIPTION
## Summary
- ensure administrators skip plan verification logic
- add script to wipe user-related tables
- expose `clean-users` npm script

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e9bca56dc8321b170f515b6b09ea1