### PR TITLE
Fix Ticto webhook validation via header

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cp .env.example .env
 Edite o `.env` com suas chaves e URLs de callback. As principais variáveis são:
 - `JWT_SECRET` – chave usada para assinar os tokens JWT
 - `SITERASTREIO_API_KEY` – chave da API do Site Rastreio
-- `TICTO_SECRET` – token para validar os webhooks da Ticto
+- `TICTO_SECRET` – token para validar os webhooks da Ticto (enviado no header `X-Ticto-Token`)
 - `PORT` – porta em que o servidor irá rodar (padrão 3000)
 - `DB_PATH` – caminho para o arquivo SQLite (opcional)
 
@@ -133,7 +133,7 @@ As configurações de integração (como a chave de postback e a API do Site Ras
 
 ## 💳 Integração com a Ticto
 
-Configure a variável `TICTO_SECRET` no `.env`. Esse token será usado para validar os webhooks enviados pela Ticto sempre que uma compra for aprovada.
+Configure a variável `TICTO_SECRET` no `.env`. Esse token deve coincidir com o valor enviado pela Ticto no cabeçalho `X-Ticto-Token` sempre que uma compra for aprovada.
 
 Ao receber um webhook válido, o servidor criará a conta do usuário (caso ainda não exista), atribuirá o plano adquirido e enviará um e-mail de boas-vindas com uma senha provisória.
 

--- a/src/controllers/integrationsController.js
+++ b/src/controllers/integrationsController.js
@@ -14,7 +14,7 @@ exports.receberPostback = async (req, res) => {
     const clienteId = req.user.id;
 
     const payload = req.body;
-    const token = payload.token || payload.basic_authentication;
+    const tictoToken = req.headers['x-ticto-token'];
     const email = payload.customer_email || payload.email;
     const planId = payload.product_id || payload.plan_id;
     const status = (payload.transaction_status || payload.status || '').toLowerCase();
@@ -24,7 +24,7 @@ exports.receberPostback = async (req, res) => {
     const config = await integrationService.getConfig(db, clienteId);
     const secret = (config && config.postback_secret) || process.env.TICTO_SECRET || '';
 
-    if (token !== secret) {
+    if (tictoToken !== secret) {
         console.warn(`[Integração] Recebida requisição com token inválido.`);
         return res.status(401).json({ error: 'Token inválido' });
     }


### PR DESCRIPTION
## Summary
- validate Ticto webhook using the `X-Ticto-Token` header
- document header-based validation in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ea9f83b9c832187a730ae87180e07