### PR TITLE
Add connection test route

### DIFF
--- a/server.js
+++ b/server.js
@@ -211,6 +211,12 @@ const startApp = async () => {
             res.sendFile(path.join(__dirname, 'public', 'admin.html'));
         });
 
+        // ROTA DE TESTE PÚBLICA PARA DIAGNÓSTICO
+        app.get('/api/teste-conexao', (req, res) => {
+            console.log('✅ SUCESSO! A rota de teste foi acessada!');
+            res.status(200).json({ message: 'Se voce esta vendo isso, a conexao com o servidor Node.js esta funcionando.' });
+        });
+
         // Middleware de autenticação para rotas abaixo
         app.use(authMiddleware);
 


### PR DESCRIPTION
## Summary
- expose `/api/teste-conexao` before authentication middleware to confirm Nginx forwarding

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ece74a2cc83218615fe8bd1e382d1