### PR TITLE
Fix upgrade button prevention

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1044,9 +1044,13 @@ const planStatusEl = document.getElementById('plan-status');
         });
     });
 
-    if (plansListEl) plansListEl.addEventListener('click', (e) => {
-        e.preventDefault();
-    });
+    if (plansListEl) {
+        plansListEl.addEventListener('click', (e) => {
+            if (!e.target.closest('a.btn-primary')) {
+                e.preventDefault();
+            }
+        });
+    }
 
     if (btnUpgradePlansEl) btnUpgradePlansEl.addEventListener('click', () => {
         if(modalUpgradeEl) modalUpgradeEl.classList.remove('active');


### PR DESCRIPTION
## Summary
- fix event listener for plans list so upgrade buttons open checkout links

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68631e60fed88321a1920ee6d81e098c