### PR TITLE
Remove plano Pro Plus e redesign do card de contato

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -776,7 +776,11 @@ const planStatusEl = document.getElementById('plan-status');
 
             plansListEl.innerHTML = '';
 
-            const upgradeablePlans = allPlans.filter(p => p.id !== activePlanId && p.name !== 'Grátis');
+            const upgradeablePlans = allPlans.filter(p =>
+                p.id !== activePlanId &&
+                p.name !== 'Grátis' &&
+                p.name !== 'Pro Plus'
+            );
 
             upgradeablePlans.forEach(p => {
                 const card = document.createElement('div');
@@ -820,9 +824,15 @@ const planStatusEl = document.getElementById('plan-status');
             const contactCard = document.createElement('div');
             contactCard.className = 'custom-plan-card';
             contactCard.innerHTML = `
-                <div>
-                    <h4>Precisa de mais de 250 pedidos?</h4>
-                    <p>Oferecemos planos empresariais com limites personalizados e suporte dedicado. Vamos conversar?</p>
+                <div class="custom-plan-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor" viewBox="0 0 16 16">
+                        <path d="M14 1a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1h-2.5a2 2 0 0 0-1.6.8L8 14.333 6.1 11.8a2 2 0 0 0-1.6-.8H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2.5a1 1 0 0 1 .8.4l1.9 2.533a1 1 0 0 0 1.6 0l1.9-2.533a1 1 0 0 1 .8-.4H14a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>
+                        <path d="M5 6a1 1 0 1 1-2 0 1 1 0 0 1 2 0m4 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0m4 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
+                    </svg>
+                </div>
+                <div class="custom-plan-text">
+                    <h4>Precisa de um plano empresarial?</h4>
+                    <p>Oferecemos limites personalizados e suporte dedicado. Vamos conversar?</p>
                 </div>
                 <a href="#" class="btn-plan btn-secondary">Entrar em Contato</a>
             `;

--- a/public/style.css
+++ b/public/style.css
@@ -819,33 +819,6 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     cursor: not-allowed;
 }
 
-/* Card de Contato Personalizado */
-.custom-plan-card {
-    grid-column: 1 / -1;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background-color: #fff;
-    border: 1px solid var(--border-color);
-    border-radius: 16px;
-    padding: 30px;
-    gap: 20px;
-}
-.custom-plan-card h4 {
-    font-size: 1.2rem; margin: 0 0 5px 0;
-}
-.custom-plan-card p {
-    margin: 0; color: var(--text-secondary);
-}
-
-@media(max-width: 768px) {
-    .custom-plan-card {
-        flex-direction: column;
-        text-align: center;
-    }
-}
-
-/* Remove os estilos antigos e genéricos se ainda existirem */
 #plans-list .plan-card .badge,
 #plans-list .plan-card .plan-features li::before {
     display: none;
@@ -910,4 +883,66 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     background-color: var(--success-color);
     border-radius: 4px;
     transition: width 0.5s ease-in-out;
+}
+
+/* =================================
+   ESTILOS FINAIS PARA O CARD DE CONTATO
+   ================================= */
+.custom-plan-card {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    gap: 25px;
+    background: linear-gradient(135deg, #f8fafc, #eff6ff);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 30px;
+    transition: all 0.2s ease-out;
+}
+
+.custom-plan-card:hover {
+    border-color: var(--primary-color);
+    box-shadow: 0 4px 15px -2px rgba(59, 130, 246, 0.1);
+}
+
+.custom-plan-icon {
+    flex-shrink: 0;
+    width: 60px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: white;
+    border-radius: 50%;
+    color: var(--primary-color);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
+
+.custom-plan-text {
+    flex-grow: 1;
+}
+
+.custom-plan-text h4 {
+    font-family: 'Poppins', sans-serif;
+    font-size: 1.2rem;
+    margin: 0 0 5px 0;
+    color: var(--text-color);
+}
+
+.custom-plan-text p {
+    margin: 0;
+    color: var(--text-secondary);
+}
+
+.custom-plan-card .btn-plan {
+    flex-shrink: 0;
+}
+
+
+/* Ajustes de responsividade para o card de contato */
+@media(max-width: 768px) {
+    .custom-plan-card {
+        flex-direction: column;
+        text-align: center;
+    }
 }


### PR DESCRIPTION
## Resumo
- remove a opção de plano "Pro Plus" da página de assinaturas
- adiciona novo layout para o card de contato

## Testes
- `node -c public/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6863326f254883218c9fdd2eee0edeeb