### PR TITLE
Atualiza painel de relatórios

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -357,15 +357,15 @@
                         <div class="report-card alert-card">
                             <div class="report-card-icon">⚠️</div>
                             <div>
-                                <h4>Pedidos com Alerta</h4>
-                                <p id="alert-orders-card">0</p>
+                                <h4>Pedidos em Atraso</h4>
+                                <p id="delayed-orders-card">0</p>
                             </div>
                         </div>
-                        <div class="report-card success-card">
-                            <div class="report-card-icon">✅</div>
+                        <div class="report-card danger-card">
+                            <div class="report-card-icon">❌</div>
                             <div>
-                                <h4>Taxa de Entrega</h4>
-                                <p id="delivery-rate-card">0%</p>
+                                <h4>Pedidos Cancelados</h4>
+                                <p id="cancelled-orders-card">0</p>
                             </div>
                         </div>
                     </div>

--- a/public/style.css
+++ b/public/style.css
@@ -1294,3 +1294,8 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 .meta-divider {
     color: var(--border-color);
 }
+
+.report-card.danger-card {
+    background-color: #fee2e2;
+    border-color: #ef4444;
+}


### PR DESCRIPTION
## Summary
- ajusta a API para retornar pedidos em atraso e cancelados
- atualiza os cards exibidos na página de relatórios
- muda o gráfico de barras para rosca
- adiciona estilo para o novo card de cancelados

## Testing
- `node --check public/script.js`
- `node --check src/controllers/reportsController.js`


------
https://chatgpt.com/codex/tasks/task_e_6863508aa1d483219aa80b42812b8380