### PR TITLE
Fix register not skipping password change

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -11,7 +11,9 @@ exports.register = async (req, res) => {
     try {
         const existing = await userService.findUserByEmail(req.db, email);
         if (existing) return res.status(409).json({ error: 'Usuário já existe.' });
-        const user = await userService.createUser(req.db, email, password);
+        // Indica que o usuário não precisa trocar a senha ao primeiro login
+        // (isAdmin=0, isActive=1, needsPasswordChange=0)
+        const user = await userService.createUser(req.db, email, password, 0, 1, 0);
         await subscriptionService.createSubscription(req.db, user.id, 1);
         res.status(201).json({ id: user.id, email: user.email, apiKey: user.api_key });
     } catch (err) {


### PR DESCRIPTION
## Summary
- ensure newly registered users aren't forced to change password

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686364b2ab6483218f93734bcc7d8551