### PR TITLE
Add webhook setup instructions card

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -237,6 +237,38 @@
                         </div>
                         <button class="btn-tertiary" id="btn-regenerate-webhook">Regenerar Link</button>
                     </div>
+                    <div class="integration-card instructions-card">
+                        <h3>Como Configurar a Automação Completa</h3>
+                        <p>Para automatizar todo o processo, você precisa configurar <strong>dois Webhooks (Postbacks)</strong> na sua plataforma de vendas (Hotmart, Kiwify, etc.). Use o seu "Link de Postback" acima para ambos.</p>
+
+                        <div class="instruction-step">
+                            <h4>1. Webhook de Venda Aprovada</h4>
+                            <p>Este aviso cria o contato no WhatsShip assim que a venda é feita. Configure-o para ser enviado no evento de <strong>"Compra Aprovada"</strong> ou <strong>"Boleto Pago"</strong>.</p>
+                            <p>O seu sistema precisa de receber, no mínimo, o e-mail do cliente. Exemplo de dados:</p>
+                            <pre><code>{
+    "event": "purchase_approved",
+    "customer": {
+        "name": "João da Silva",
+        "email": "joao.silva@email.com",
+        "phone": { "ddd": "11", "number": "999998888" }
+    }
+}</code></pre>
+                        </div>
+
+                        <div class="instruction-step">
+                            <h4>2. Webhook de Código de Rastreio</h4>
+                            <p>Este segundo aviso atualiza o contato que já existe com o código de rastreio. Configure-o para o evento de <strong>"Código de Rastreio Cadastrado"</strong> na sua plataforma.</p>
+                            <p>Ele precisa de enviar o e-mail (para sabermos qual contato atualizar) e o novo código. Exemplo de dados:</p>
+                            <pre><code>{
+    "event": "tracking_code_added",
+    "customer": {
+        "email": "joao.silva@email.com"
+    },
+    "tracking_code": "BR123456789BR"
+}</code></pre>
+                        </div>
+                        <p class="instruction-note"><strong>Importante:</strong> Os nomes dos campos (como <code>event</code>, <code>customer</code>, <code>tracking_code</code>) podem variar entre as plataformas. Consulte a documentação da sua plataforma de vendas para saber os nomes exatos dos campos e eventos.</p>
+                    </div>
                     <div class="integration-card">
                         <h3>Chave Secreta de Postback</h3>
                         <p>Insira abaixo a chave secreta utilizada para validar os postbacks de qualquer plataforma de vendas (Hotmart, Kiwify, etc.).</p>

--- a/public/style.css
+++ b/public/style.css
@@ -1355,3 +1355,57 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     width: 100%;
     padding: 12px;
 }
+
+/* =================================
+   ESTILOS PARA O CARD DE INSTRUÇÕES
+   ================================= */
+
+.instructions-card {
+    background-color: #f8fafc; /* Um fundo ligeiramente diferente para destacar */
+    border-style: dashed;
+}
+
+.instruction-step {
+    margin-top: 25px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border-color);
+}
+
+.instruction-step:first-of-type {
+    margin-top: 20px;
+}
+
+
+.instruction-step h4 {
+    font-size: 1.1rem;
+    color: var(--text-color);
+    margin-bottom: 8px;
+}
+
+.instruction-step p {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin-bottom: 15px;
+}
+
+.instruction-step pre {
+    background-color: #1f2937; /* Fundo escuro para o código */
+    color: #f3f4f6;
+    padding: 15px;
+    border-radius: 8px;
+    font-family: monospace;
+    font-size: 0.85rem;
+    white-space: pre-wrap; /* Garante a quebra de linha */
+    word-break: break-all;
+}
+
+.instruction-note {
+    margin-top: 25px;
+    padding: 15px;
+    background-color: #fffbeb; /* Fundo de alerta amarelo claro */
+    color: #b45309;
+    border: 1px solid #fde68a;
+    border-radius: 8px;
+    font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- document how to set up the two required webhooks
- style the new instructions card for better readability

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865a8b119588321b4ac9fe55e5f9fe9