### PR TITLE
Add webhook translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ POST https://seu-servidor/api/postback?key=SUA_API_KEY
 1. **Venda Aprovada** (`purchase_approved` ou equivalente) – envia nome, telefone e produto do cliente. O pedido é criado sem código de rastreio.
 2. **Código de Rastreio Adicionado** (`tracking_code_added`) – envia o telefone do cliente e o campo `tracking_code`. O pedido existente é atualizado com o código e o uso do plano é incrementado.
 
-Consulte a documentação da sua plataforma para confirmar os nomes dos eventos e campos enviados.
+Nosso servidor já reconhece automaticamente webhooks da Hotmart e da Kiwify, convertendo os campos para esse formato padronizado. Em outras plataformas, mantenha os nomes o mais próximo possível do exemplo acima.
 
 ---
 


### PR DESCRIPTION
## Summary
- detect Hotmart or Kiwify payloads by headers/fields
- translate webhook data to the internal format
- mention automatic translation in docs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865b048fc2c8321878650b36d3b7309