### PR TITLE
Add secret key field for integrations

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -263,7 +263,10 @@
                             <div class="settings-card-body">
                                 <label for="integration-name">Apelido da Integração</label>
                                 <input type="text" id="integration-name" placeholder="Ex: Minha Loja na Kiwify">
-                                
+
+                                <label for="integration-secret">Chave Secreta (ou Token)</label>
+                                <input type="text" id="integration-secret" placeholder="Cole a chave da sua plataforma aqui">
+
                                 <label for="integration-webhook-url">Sua URL de Webhook</label>
                                 <div class="webhook-url-container">
                                     <div id="integration-webhook-url" class="webhook-url-display">Aguardando...</div>

--- a/public/script.js
+++ b/public/script.js
@@ -1446,6 +1446,7 @@ const platformGrid = document.getElementById('platform-grid');
     const setupTitle = document.getElementById('setup-title');
     const platformInstructions = document.getElementById('platform-instructions');
     const inputIntegrationName = document.getElementById('integration-name');
+    const inputIntegrationSecret = document.getElementById('integration-secret');
     const webhookDisplay = document.getElementById('integration-webhook-url');
 
     const instructions = {
@@ -1463,6 +1464,7 @@ const platformGrid = document.getElementById('platform-grid');
         const platformInstructionsEl = document.getElementById('platform-instructions');
         const webhookUrlDisplayEl = document.getElementById('integration-webhook-url');
         const integrationNameInput = document.getElementById('integration-name');
+        const integrationSecretInput = document.getElementById('integration-secret');
         const btnSaveIntegration = document.getElementById('btn-save-integration');
 
         setupTitleEl.textContent = `Configurar Integração com ${platform.name}`;
@@ -1470,6 +1472,7 @@ const platformGrid = document.getElementById('platform-grid');
 
         // Limpa os campos e desativa o botão de salvar
         integrationNameInput.value = '';
+        integrationSecretInput.value = '';
         webhookUrlDisplayEl.textContent = 'A gerar URL...';
         btnSaveIntegration.disabled = true;
 
@@ -1497,16 +1500,20 @@ const platformGrid = document.getElementById('platform-grid');
             // 3. Configura o botão "Salvar" para atualizar o nome da integração
             btnSaveIntegration.onclick = async () => {
                 const integrationName = integrationNameInput.value.trim();
+                const secretKey = integrationSecretInput.value.trim();
                 if (!integrationName) {
                     alert('Por favor, dê um apelido à sua integração.');
                     return;
                 }
                 try {
-                    // Atualiza o nome da integração que acabámos de criar
+                    // Atualiza o nome e a chave secreta da integração
                     await authFetch(`/api/integrations/${newIntegration.id}`, {
                         method: 'PUT',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ name: integrationName })
+                        body: JSON.stringify({ 
+                            name: integrationName,
+                            secret_key: secretKey
+                        })
                     });
                     showNotification('Integração salva com sucesso!', 'success');
                     showIntegrationsList();

--- a/server.js
+++ b/server.js
@@ -306,6 +306,7 @@ const startApp = async () => {
         // Rotas de Integrações (UNIFICADAS)
         app.get('/api/integrations/info', planCheck, integrationsController.getIntegrationInfo);
         app.post('/api/integrations', planCheck, integrationsController.criarIntegracao);
+        app.put('/api/integrations/:id', planCheck, integrationsController.atualizarIntegracao);
         app.post('/api/integrations/regenerate', planCheck, integrationsController.regenerateApiKey);
         app.put('/api/integrations/settings', planCheck, integrationsController.updateIntegrationSettings);
         app.get('/api/integrations/history', planCheck, integrationsController.listarHistorico);

--- a/src/controllers/integrationsController.js
+++ b/src/controllers/integrationsController.js
@@ -86,6 +86,18 @@ exports.criarIntegracao = async (req, res) => {
     }
 };
 
+exports.atualizarIntegracao = async (req, res) => {
+    const { id } = req.params;
+    const { name, secret_key } = req.body;
+    try {
+        await integrationService.updateIntegration(req.db, id, { name, secret_key });
+        res.status(200).json({ message: 'Integração atualizada' });
+    } catch (err) {
+        console.error('Erro ao atualizar integração', err);
+        res.status(500).json({ error: 'Falha ao atualizar integração' });
+    }
+};
+
 exports.updateIntegrationSettings = async (req, res) => {
     try {
         await integrationConfigService.updateConfig(req.db, req.user.id, req.body);

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -224,6 +224,7 @@ const initDb = () => {
                             platform TEXT NOT NULL,
                             name TEXT NOT NULL,
                             unique_path TEXT NOT NULL UNIQUE,
+                            secret_key TEXT,
                             status TEXT DEFAULT 'active',
                             FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
                         )
@@ -314,6 +315,10 @@ const initDb = () => {
                     });
                     db.run("ALTER TABLE pedidos ADD COLUMN notas TEXT", [], (e) => {
                         if (e && !e.message.includes('duplicate column')) return reject(e);
+                    });
+
+                    db.run("ALTER TABLE integrations ADD COLUMN secret_key TEXT", [], (e) => {
+                        if (e && !e.message.includes('duplicate')) return reject(e);
                     });
 
                     // Bloco movido para dentro da criação da tabela 'users'

--- a/src/services/integrationService.js
+++ b/src/services/integrationService.js
@@ -1,9 +1,31 @@
-function createIntegration(db, userId, platform, name, uniquePath, status = 'active') {
+function createIntegration(db, userId, platform, name, uniquePath, secretKey = null, status = 'active') {
     return new Promise((resolve, reject) => {
-        const sql = `INSERT INTO integrations (user_id, platform, name, unique_path, status) VALUES (?, ?, ?, ?, ?)`;
-        db.run(sql, [userId, platform, name, uniquePath, status], function(err) {
+        const sql = `INSERT INTO integrations (user_id, platform, name, unique_path, secret_key, status) VALUES (?, ?, ?, ?, ?, ?)`;
+        db.run(sql, [userId, platform, name, uniquePath, secretKey, status], function(err) {
             if (err) return reject(err);
             resolve({ id: this.lastID });
+        });
+    });
+}
+
+function updateIntegration(db, id, fields) {
+    const sets = [];
+    const params = [];
+    if (fields.name !== undefined) {
+        sets.push('name = ?');
+        params.push(fields.name);
+    }
+    if (fields.secret_key !== undefined) {
+        sets.push('secret_key = ?');
+        params.push(fields.secret_key);
+    }
+    if (!sets.length) return Promise.resolve();
+    params.push(id);
+    const sql = `UPDATE integrations SET ${sets.join(', ')} WHERE id = ?`;
+    return new Promise((resolve, reject) => {
+        db.run(sql, params, function(err) {
+            if (err) return reject(err);
+            resolve({ changes: this.changes });
         });
     });
 }
@@ -17,4 +39,4 @@ function findIntegrationByPath(db, uniquePath) {
     });
 }
 
-module.exports = { createIntegration, findIntegrationByPath };
+module.exports = { createIntegration, findIntegrationByPath, updateIntegration };


### PR DESCRIPTION
## Summary
- support secret keys for integrations
- expose integration update endpoint
- add secret key input on setup screen
- capture secret key when saving integration

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686667bef5908321804ec0fdb19010d6