### PR TITLE
Add integration management features

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -120,6 +120,11 @@ body {
 .btn-salvar { background-color: var(--primary-color); }
 .btn-icon { background-color: transparent; border: none; color: var(--text-secondary); width: 40px; height: 40px; border-radius: 50%; cursor: pointer; display: flex; align-items: center; justify-content: center; }
 .btn-icon:hover { background-color: var(--hover-bg); }
+/* Destaque para o botão de excluir integração */
+.btn-delete-integration:hover {
+    color: var(--error-color);
+    background-color: #fee2e2;
+}
 #btn-adicionar-novo { background-color: var(--primary-color); color: white; font-size: 1.8rem; line-height: 1; }
 #btn-adicionar-novo:hover { background-color: #2563eb; }
 .btn-editar-main, .btn-atualizar-foto { background-color: var(--primary-color); border: none; color: #fff; padding: 10px 16px; border-radius: 6px; cursor: pointer; margin-left: 10px; display: flex; align-items: center; gap: 6px; }

--- a/server.js
+++ b/server.js
@@ -308,6 +308,7 @@ const startApp = async () => {
         app.get('/api/integrations/info', planCheck, integrationsController.getIntegrationInfo);
         app.post('/api/integrations', planCheck, integrationsController.criarIntegracao);
         app.put('/api/integrations/:id', planCheck, integrationsController.atualizarIntegracao);
+        app.delete('/api/integrations/:id', integrationsController.deletarIntegracao);
         app.post('/api/integrations/regenerate', planCheck, integrationsController.regenerateApiKey);
         app.put('/api/integrations/settings', planCheck, integrationsController.updateIntegrationSettings);
         app.get('/api/integrations/history', planCheck, integrationsController.listarHistorico);

--- a/src/controllers/integrationsController.js
+++ b/src/controllers/integrationsController.js
@@ -101,13 +101,37 @@ exports.criarIntegracao = async (req, res) => {
 
 exports.atualizarIntegracao = async (req, res) => {
     const { id } = req.params;
+    const clienteId = req.user.id;
     const { name, secret_key } = req.body;
     try {
-        await integrationService.updateIntegration(req.db, id, { name, secret_key });
-        res.status(200).json({ message: 'Integração atualizada' });
+        const result = await integrationService.updateIntegration(
+            req.db,
+            id,
+            { name, secret_key },
+            clienteId
+        );
+        if (result.changes === 0) {
+            return res.status(404).json({ error: 'Integração não encontrada.' });
+        }
+        res.status(200).json({ message: 'Integração atualizada com sucesso.' });
     } catch (err) {
         console.error('Erro ao atualizar integração', err);
         res.status(500).json({ error: 'Falha ao atualizar integração' });
+    }
+};
+
+exports.deletarIntegracao = async (req, res) => {
+    const { id } = req.params;
+    const clienteId = req.user.id;
+    try {
+        const result = await integrationService.deleteIntegration(req.db, id, clienteId);
+        if (result.changes === 0) {
+            return res.status(404).json({ error: 'Integração não encontrada.' });
+        }
+        res.status(200).json({ message: 'Integração excluída com sucesso.' });
+    } catch (err) {
+        console.error('Erro ao excluir integração', err);
+        res.status(500).json({ error: 'Falha ao excluir integração' });
     }
 };
 

--- a/src/services/integrationService.js
+++ b/src/services/integrationService.js
@@ -8,7 +8,7 @@ function createIntegration(db, userId, platform, name, uniquePath, secretKey = n
     });
 }
 
-function updateIntegration(db, id, fields) {
+function updateIntegration(db, id, fields, userId = null) {
     const sets = [];
     const params = [];
     if (fields.name !== undefined) {
@@ -21,7 +21,11 @@ function updateIntegration(db, id, fields) {
     }
     if (!sets.length) return Promise.resolve();
     params.push(id);
-    const sql = `UPDATE integrations SET ${sets.join(', ')} WHERE id = ?`;
+    let sql = `UPDATE integrations SET ${sets.join(', ')} WHERE id = ?`;
+    if (userId !== null) {
+        sql += ' AND user_id = ?';
+        params.push(userId);
+    }
     return new Promise((resolve, reject) => {
         db.run(sql, params, function(err) {
             if (err) return reject(err);
@@ -39,4 +43,40 @@ function findIntegrationByPath(db, uniquePath) {
     });
 }
 
-module.exports = { createIntegration, findIntegrationByPath, updateIntegration };
+function getIntegrationById(db, id, userId = null) {
+    return new Promise((resolve, reject) => {
+        let sql = 'SELECT * FROM integrations WHERE id = ?';
+        const params = [id];
+        if (userId !== null) {
+            sql += ' AND user_id = ?';
+            params.push(userId);
+        }
+        db.get(sql, params, (err, row) => {
+            if (err) return reject(err);
+            resolve(row);
+        });
+    });
+}
+
+function deleteIntegration(db, id, userId = null) {
+    return new Promise((resolve, reject) => {
+        let sql = 'DELETE FROM integrations WHERE id = ?';
+        const params = [id];
+        if (userId !== null) {
+            sql += ' AND user_id = ?';
+            params.push(userId);
+        }
+        db.run(sql, params, function(err) {
+            if (err) return reject(err);
+            resolve({ changes: this.changes });
+        });
+    });
+}
+
+module.exports = {
+    createIntegration,
+    findIntegrationByPath,
+    updateIntegration,
+    getIntegrationById,
+    deleteIntegration,
+};


### PR DESCRIPTION
## Summary
- support deletion and update of integrations via API
- adjust integration service for deletion and fetching helpers
- display edit and delete buttons and correct logos in the UI
- enable editing integrations with pre-filled data
- highlight delete button on hover

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68667ed016f48321a76471eb3dc3a9d9