### PR TITLE
Fix platform tile alignment

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1506,6 +1506,7 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     font-size: 0.9rem;
     transition: background-color 0.2s ease-out, transform 0.2s ease-out;
     height: 120px; /* Adiciona altura fixa para alinhar as opções */
+    flex-direction: column;
 }
 .platform-tile img {
     max-width: 60px;


### PR DESCRIPTION
## Summary
- adjust `.platform-tile` style to stack logo and name vertically

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68668fda24a08321b9b1aec89a0ac348