### PR TITLE
Fix platform tile layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1497,16 +1497,17 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     padding: 5px;
 }
 .platform-tile {
-    padding: 15px 20px;
+    display: flex;
+    flex-direction: column; /* Esta é a linha que resolve o problema */
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 20px;
     border: 1px solid var(--border-color);
     border-radius: 12px;
     cursor: pointer;
-    text-align: center;
-    font-weight: 500;
-    font-size: 0.9rem;
-    transition: background-color 0.2s ease-out, transform 0.2s ease-out;
-    height: 120px; /* Adiciona altura fixa para alinhar as opções */
-    flex-direction: column;
+    transition: all 0.2s ease-out;
+    height: 120px;
 }
 .platform-tile img {
     max-width: 60px;


### PR DESCRIPTION
## Summary
- fix flex layout for platform tile so logo and text stack vertically

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866a09e2194832182b548aa05408c26