### PR TITLE
Enable per-user WhatsApp sessions

### DIFF
--- a/src/controllers/pedidosController.js
+++ b/src/controllers/pedidosController.js
@@ -108,7 +108,7 @@ exports.criarPedido = [
 
             await subscriptionService.incrementUsage(db, sub.id);
 
-            await envioController.enviarMensagemBoasVindas(db, pedidoCriado, req.broadcast);
+            await envioController.enviarMensagemBoasVindas(db, pedidoCriado, req.broadcast, client);
             req.broadcast({ type: 'novo_contato', pedido: pedidoCriado });
             await logService.addLog(db, clienteId, 'pedido_criado', JSON.stringify({ pedidoId: pedidoCriado.id }));
 
@@ -205,7 +205,7 @@ exports.enviarMensagemManual = async (req, res) => {
         const pedido = await pedidoService.getPedidoById(db, id, clienteId);
         if (!pedido) return res.status(404).json({ error: "Pedido não encontrado." });
 
-        await whatsappService.enviarMensagem(pedido.telefone, mensagem);
+        await whatsappService.enviarMensagem(req.venomClient, pedido.telefone, mensagem);
         await pedidoService.addMensagemHistorico(db, id, mensagem, 'manual', 'bot', clienteId);
 
         await logService.addLog(db, clienteId, 'mensagem_manual', JSON.stringify({ pedidoId: id }));
@@ -238,7 +238,7 @@ exports.atualizarFotoDoPedido = async (req, res) => {
             return res.status(404).json({ error: "Pedido não encontrado." });
         }
 
-        const fotoUrl = await whatsappService.getProfilePicUrl(pedido.telefone);
+        const fotoUrl = await whatsappService.getProfilePicUrl(client, pedido.telefone);
         
         if (fotoUrl) {
             await pedidoService.updateCamposPedido(db, id, { fotoPerfilUrl: fotoUrl }, clienteId);

--- a/src/services/pedidoService.js
+++ b/src/services/pedidoService.js
@@ -278,7 +278,7 @@ const criarPedido = (db, dadosPedido, client, clienteId = null) => {
         let fotoUrl = null;
         if (client) {
             try {
-                fotoUrl = await whatsappService.getProfilePicUrl(telefoneValidado);
+                fotoUrl = await whatsappService.getProfilePicUrl(client, telefoneValidado);
             } catch (e) {
                 console.warn(`Não foi possível obter a foto para o novo contato ${telefoneValidado}.`);
                 fotoUrl = null;

--- a/src/services/whatsappService.js
+++ b/src/services/whatsappService.js
@@ -1,6 +1,4 @@
 // src/services/whatsappService.js
-let client = null;
-
 // --- FUNÇÕES DE AJUDA ---
 
 /**
@@ -24,7 +22,7 @@ function normalizeTelefone(telefoneRaw) {
  * @param {string} telefone - número sem máscara.
  * @returns {Promise<string|null>} URL da foto, ou null.
  */
-async function scrapeProfilePicViaPuppeteer(telefone) {
+async function scrapeProfilePicViaPuppeteer(client, telefone) {
   const tel = normalizeTelefone(telefone);
   const page = client.page;
   
@@ -79,11 +77,11 @@ async function scrapeProfilePicViaPuppeteer(telefone) {
 
 // --- FUNÇÕES PRINCIPAIS DO SERVIÇO ---
 
-function iniciarWhatsApp(venomClient) {
-    client = venomClient;
+function iniciarWhatsApp() {
+    // Mantido para compatibilidade futura
 }
 
-async function enviarMensagem(telefone, mensagem) {
+async function enviarMensagem(client, telefone, mensagem) {
     if (!client) throw new Error('Cliente WhatsApp não iniciado.');
     const numeroNormalizado = normalizeTelefone(telefone);
     const numeroFormatado = `${numeroNormalizado}@c.us`;
@@ -95,7 +93,7 @@ async function enviarMensagem(telefone, mensagem) {
  * @param {string} telefone O número do contato.
  * @returns {Promise<string|null>} A URL da foto ou nulo se não existir.
  */
-async function getProfilePicUrl(telefone) {
+async function getProfilePicUrl(client, telefone) {
     if (!client) {
         console.warn("Cliente Venom não está pronto para buscar fotos.");
         return null;
@@ -114,7 +112,7 @@ async function getProfilePicUrl(telefone) {
 
     // --- ESTRATÉGIA 2: FALLBACK VIA SCRAPING ROBUSTO COM PUPPETEER ---
     try {
-        const viaScrape = await scrapeProfilePicViaPuppeteer(telefone);
+        const viaScrape = await scrapeProfilePicViaPuppeteer(client, telefone);
         if (viaScrape) {
         }
         return viaScrape;


### PR DESCRIPTION
## Summary
- support multiple WhatsApp sessions using a session map
- adjust whatsapp service to require explicit client
- use correct client in pedidos and envio controllers
- update background tasks and routes to access the user's session

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866be349064832198341091d42f9b65