### PR TITLE
Fix CSP to allow WhatsApp profile pictures

### DIFF
--- a/server.js
+++ b/server.js
@@ -196,7 +196,8 @@ const startApp = async () => {
                 directives: {
                     ...helmet.contentSecurityPolicy.getDefaultDirectives(),
                     "script-src": ["'self'", "https://cdn.jsdelivr.net"],
-                    "img-src": ["'self'", "data:", "blob:", "https://i.imgur.com"],
+                    // LINHA ATUALIZADA ABAIXO
+                    "img-src": ["'self'", "data:", "blob:", "https://i.imgur.com", "https://static.whatsapp.net", "https://pps.whatsapp.net"],
                     "connect-src": ["'self'", "wss:", "ws:"]
                 },
             },


### PR DESCRIPTION
## Summary
- allow WhatsApp domains in Helmet CSP so profile images load

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866c79e6da0832192b1144d12fd80c4