### PR TITLE
Add broadcast after webhook contact creation

### DIFF
--- a/src/controllers/integrationsController.js
+++ b/src/controllers/integrationsController.js
@@ -52,6 +52,22 @@ exports.receberPostback = async (req, res) => {
         const dados = mapper(payload);
 
         switch (dados.eventType) {
+            case 'VENDA_APROVADA': {
+                const pedidoExistente = await pedidoService.findPedidoByEmail(req.db, dados.clientEmail, nossoUsuario.id);
+                if (!pedidoExistente) {
+                    const pedidoCriado = await pedidoService.criarPedido(req.db, {
+                        nome: dados.clientName,
+                        telefone: dados.clientPhone,
+                        email: dados.clientEmail,
+                        produto: dados.productName,
+                    }, req.venomClient, nossoUsuario.id);
+
+                    req.broadcast({ type: 'novo_contato', pedido: pedidoCriado });
+
+                    console.log(`[Webhook] Contato para ${dados.clientName} criado com sucesso.`);
+                }
+                break;
+            }
             case 'RASTREIO_ADICIONADO':
                 const pedido = await pedidoService.findPedidoByEmail(req.db, dados.clientEmail, nossoUsuario.id);
                 // etc...


### PR DESCRIPTION
## Summary
- send websocket update after creating a contact via webhook

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866ec1222ec8321b0bba2f0d1c9f3ac