### PR TITLE
Refactor session handling for WhatsApp

### DIFF
--- a/src/controllers/pedidosController.js
+++ b/src/controllers/pedidosController.js
@@ -205,6 +205,10 @@ exports.enviarMensagemManual = async (req, res) => {
         const pedido = await pedidoService.getPedidoById(db, id, clienteId);
         if (!pedido) return res.status(404).json({ error: "Pedido não encontrado." });
 
+        if (!req.venomClient) {
+            return res.status(409).json({ error: 'A sua conta não está conectada ao WhatsApp.' });
+        }
+
         await whatsappService.enviarMensagem(req.venomClient, pedido.telefone, mensagem);
         await pedidoService.addMensagemHistorico(db, id, mensagem, 'manual', 'bot', clienteId);
 

--- a/src/services/pedidoService.js
+++ b/src/services/pedidoService.js
@@ -278,7 +278,7 @@ const criarPedido = (db, dadosPedido, client, clienteId = null) => {
         let fotoUrl = null;
         if (client) {
             try {
-                fotoUrl = await whatsappService.getProfilePicUrl(telefoneValidado);
+                fotoUrl = await whatsappService.getProfilePicUrl(client, telefoneValidado);
             } catch (e) {
                 console.warn(`Não foi possível obter a foto para o novo contato ${telefoneValidado}.`);
                 fotoUrl = null;


### PR DESCRIPTION
## Summary
- pass Venom client to profile picture lookup
- error when trying to send a message without an active WhatsApp session

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68671c6d54288321b11d0917ec99b65d