### PR TITLE
Require JWT secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cp .env.example .env
 ```
 
 Edite o `.env` com suas chaves e URLs de callback. As principais variáveis são:
-- `JWT_SECRET` – chave usada para assinar os tokens JWT
+- `JWT_SECRET` – **obrigatória**. Chave usada para assinar os tokens JWT; o servidor não inicia sem ela
 - `SITERASTREIO_API_KEY` – chave da API do Site Rastreio
 - `TICTO_SECRET` – token para validar os webhooks da Ticto (enviado no header `X-Ticto-Token`)
 - `PORT` – porta em que o servidor irá rodar (padrão 3000)

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -3,7 +3,10 @@ const bcrypt = require('bcryptjs');
 const userService = require('../services/userService');
 const subscriptionService = require('../services/subscriptionService');
 
-const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+    throw new Error('JWT_SECRET environment variable is required');
+}
 
 exports.register = async (req, res) => {
     const { email, password } = req.body;

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,5 +1,8 @@
 const jwt = require('jsonwebtoken');
-const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+    throw new Error('JWT_SECRET environment variable is required');
+}
 
 module.exports = (req, res, next) => {
     const authHeader = req.headers.authorization;


### PR DESCRIPTION
## Summary
- fail fast if JWT_SECRET is missing in auth modules
- clarify in README that JWT_SECRET is mandatory

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1410aac8321b657d53e025cce68