### PR TITLE
Add Dockerfile and instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+tokens

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ Edite o `.env` com suas chaves e URLs de callback. As principais variáveis são
 
 ---
 
+## 🐳 Docker
+
+Também é possível rodar o projeto em contêiner usando o Docker.
+
+### 1. Construir a imagem
+
+```bash
+docker build -t rastreamento-bot .
+```
+
+### 2. Executar o container
+
+```bash
+docker run -p 3000:3000 --env-file .env rastreamento-bot
+```
+
+Crie um arquivo `.env` (ou exporte variáveis no comando `docker run`) com as configurações necessárias, como `JWT_SECRET`, `SITERASTREIO_API_KEY` e `TICTO_SECRET`.
+
+---
+
+
 ## 🔹 Como Usar
 
 ### 1. Iniciar o servidor


### PR DESCRIPTION
## Summary
- support container builds with a new Dockerfile
- ignore tokens and node modules when building the image
- explain how to build and run the Docker container

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686bb187b79c83218b19c823c0fa880f