### PR TITLE
Add basic Jest tests and CI workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install --ignore-scripts --no-optional
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "create-admin": "node criar-admin.js",
     "clean-users": "node limpar-usuarios.js"
   },
@@ -28,5 +28,8 @@
     "winston": "^3.17.0",
     "ws": "^8.18.2",
     "xlsx": "^0.18.5"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/tests/authController.test.js
+++ b/tests/authController.test.js
@@ -1,0 +1,40 @@
+const authController = require('../src/controllers/authController');
+const userService = require('../src/services/userService');
+const subscriptionService = require('../src/services/subscriptionService');
+
+jest.mock('../src/services/userService');
+jest.mock('../src/services/subscriptionService');
+
+describe('authController.register', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = { db: {}, body: {} };
+    res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    jest.clearAllMocks();
+  });
+
+  test('creates a new user', async () => {
+    req.body = { email: 'test@example.com', password: '123' };
+    userService.findUserByEmail.mockResolvedValue(null);
+    userService.createUser.mockResolvedValue({ id: 1, email: 'test@example.com', api_key: 'key' });
+    subscriptionService.createSubscription.mockResolvedValue();
+
+    await authController.register(req, res);
+
+    expect(userService.createUser).toHaveBeenCalledWith(req.db, 'test@example.com', '123', 0, 1, 0);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ id: 1, email: 'test@example.com', apiKey: 'key' });
+  });
+
+  test('returns 409 when user exists', async () => {
+    req.body = { email: 'exist@example.com', password: '123' };
+    userService.findUserByEmail.mockResolvedValue({ id: 1 });
+
+    await authController.register(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Usuário já existe.' });
+  });
+});

--- a/tests/pedidosController.test.js
+++ b/tests/pedidosController.test.js
@@ -1,0 +1,55 @@
+const { criarPedido } = require('../src/controllers/pedidosController');
+const pedidoService = require('../src/services/pedidoService');
+const subscriptionService = require('../src/services/subscriptionService');
+const envioController = require('../src/controllers/envioController');
+const logService = require('../src/services/logService');
+const { validationResult } = require('express-validator');
+
+jest.mock('../src/services/pedidoService');
+jest.mock('../src/services/subscriptionService');
+jest.mock('../src/controllers/envioController');
+jest.mock('../src/services/logService');
+
+jest.mock('express-validator', () => {
+  const chain = { trim: () => chain, notEmpty: () => chain, withMessage: () => chain, isMobilePhone: () => chain };
+  return {
+    body: jest.fn(() => chain),
+    validationResult: jest.fn()
+  };
+});
+
+describe('pedidosController.criarPedido', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = {
+      db: {},
+      venomClient: {},
+      user: { id: 1 },
+      body: { nome: 'John', telefone: '11999999999', produto: 'Book', codigoRastreio: 'AAA' },
+      broadcast: jest.fn()
+    };
+    res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    validationResult.mockReturnValue({ isEmpty: () => true, array: () => [] });
+    subscriptionService.getUserSubscription.mockResolvedValue({ id: 10, monthly_limit: -1, usage: 0 });
+    pedidoService.findPedidoByTelefone.mockResolvedValue(null);
+    pedidoService.criarPedido.mockResolvedValue({ id: 5 });
+    jest.clearAllMocks();
+  });
+
+  test('creates a new pedido', async () => {
+    await criarPedido[3](req, res);
+
+    expect(pedidoService.criarPedido).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  test('returns 409 when pedido exists', async () => {
+    pedidoService.findPedidoByTelefone.mockResolvedValue({ id: 1 });
+
+    await criarPedido[3](req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+});


### PR DESCRIPTION
## Summary
- add `jest` as a dev dependency and update npm test script
- add tests for `authController` register flow
- add tests for `pedidosController` create flow
- run tests automatically in GitHub Actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb1938a748321a3f7ea960614ef7d