### PR TITLE
Fix free plan limit

### DIFF
--- a/seeds/initial_plans.js
+++ b/seeds/initial_plans.js
@@ -5,7 +5,7 @@ exports.seed = async function(knex) {
       id: 1,
       name: 'Gr\u00e1tis',
       price: 0,
-      monthly_limit: 50,
+      monthly_limit: 10,
       checkout_url: null
     }
   ]).onConflict('id').ignore();

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -24,7 +24,7 @@ exports.register = async (req, res) => {
         if (!freePlan) {
             await new Promise((resolve, reject) => {
                 req.db.run(
-                    'INSERT INTO plans (id, name, price, monthly_limit) VALUES (1, ? , 0, 50)',
+                    'INSERT INTO plans (id, name, price, monthly_limit) VALUES (1, ? , 0, 10)',
                     ['Start'],
                     err => {
                         if (err) return reject(err);


### PR DESCRIPTION
## Summary
- tweak auth controller to seed plan with 10 monthly requests
- adjust initial seed to default to 10

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc6c8e730832180c764dc4ef41c40