### PR TITLE
Isolate WhatsApp sessions by user

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -299,7 +299,7 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
 
     const connectWebSocket = () => {
         const wsProtocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-        const ws = new WebSocket(`${wsProtocol}://${window.location.host}`);
+        const ws = new WebSocket(`${wsProtocol}://${window.location.host}?token=${token}`);
         ws.onopen = () => console.log('🔗 Conexão WebSocket estabelecida.');
         ws.onmessage = (event) => {
             const data = JSON.parse(event.data);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -38,7 +38,6 @@ module.exports = function setupRoutes(app, db, sessionManager) {
 
   app.use((req, res, next) => {
     req.db = db;
-    req.broadcast = broadcast;
     next();
   });
 
@@ -66,6 +65,7 @@ module.exports = function setupRoutes(app, db, sessionManager) {
   app.use(authMiddleware);
   app.use((req, res, next) => {
     req.venomClient = activeSessions.get(req.user.id) || null;
+    req.broadcast = (data) => broadcast(req.user.id, data);
     next();
   });
 
@@ -154,7 +154,7 @@ module.exports = function setupRoutes(app, db, sessionManager) {
 
   // Rotas do WhatsApp
   app.get('/api/whatsapp/status', (req, res) =>
-    res.json({ status: getStatus(), qrCode: getQrCode(), botInfo: getBotInfo() })
+    res.json({ status: getStatus(req.user.id), qrCode: getQrCode(req.user.id), botInfo: getBotInfo(req.user.id) })
   );
   app.post('/api/whatsapp/connect', planCheck, (req, res) => {
     connectToWhatsApp(req.user.id);

--- a/src/whatsapp/sessionManager.js
+++ b/src/whatsapp/sessionManager.js
@@ -1,49 +1,71 @@
 const { WebSocketServer } = require('ws');
 const venom = require('venom-bot');
+const jwt = require('jsonwebtoken');
 const whatsappService = require('../services/whatsappService');
 const pedidoService = require('../services/pedidoService');
 const settingsService = require('../services/settingsService');
 
 let appInstance;
 let wss;
-const clients = new Set();
+// Map: userId => Set<WebSocket>
+const clients = new Map();
 
-let whatsappStatus = 'DISCONNECTED';
-let qrCodeData = null;
-let botInfo = null;
+// Map: userId => { status, qrCode, botInfo }
+const sessionData = new Map();
 const activeSessions = new Map();
 
-function broadcast(data) {
+function broadcast(userId, data) {
+  const userClients = clients.get(userId);
+  if (!userClients) return;
   const jsonData = JSON.stringify(data);
-  console.log(`[WebSocket] A transmitir: ${jsonData}`);
-  for (const client of clients) {
+  console.log(`[WebSocket] A transmitir para ${userId}: ${jsonData}`);
+  for (const client of userClients) {
     if (client.readyState === client.OPEN) {
       client.send(jsonData);
     }
   }
 }
 
-function broadcastStatus(newStatus, data = {}) {
-  whatsappStatus = newStatus;
-  qrCodeData = data.qrCode || null;
-  console.log(`Status do WhatsApp alterado para: ${newStatus}`);
-  broadcast({ type: 'status_update', status: newStatus, ...data });
+function broadcastStatus(userId, newStatus, data = {}) {
+  const info = sessionData.get(userId) || { status: 'DISCONNECTED', qrCode: null, botInfo: null };
+  info.status = newStatus;
+  if (Object.prototype.hasOwnProperty.call(data, 'qrCode')) info.qrCode = data.qrCode;
+  if (data.botInfo) info.botInfo = data.botInfo;
+  sessionData.set(userId, info);
+  console.log(`Status do WhatsApp do usuário ${userId} alterado para: ${newStatus}`);
+  broadcast(userId, { type: 'status_update', status: newStatus, ...data });
 }
 
 function setupWebSocket(server) {
   wss = new WebSocketServer({ server });
-  wss.on('connection', (ws) => {
-    console.log('🔗 Novo painel conectado via WebSocket.');
-    clients.add(ws);
+  wss.on('connection', (ws, req) => {
+    const url = new URL(req.url, 'http://localhost');
+    const token = url.searchParams.get('token');
+    let payload;
+    try {
+      payload = jwt.verify(token, process.env.JWT_SECRET);
+    } catch (err) {
+      ws.close();
+      return;
+    }
+    const userId = payload.id;
+    console.log(`🔗 Painel conectado via WebSocket para usuário ${userId}.`);
+    if (!clients.has(userId)) clients.set(userId, new Set());
+    const set = clients.get(userId);
+    set.add(ws);
+    const info = sessionData.get(userId) || { status: 'DISCONNECTED', qrCode: null, botInfo: null };
     ws.send(
       JSON.stringify({
         type: 'status_update',
-        status: whatsappStatus,
-        qrCode: qrCodeData,
-        botInfo,
+        status: info.status,
+        qrCode: info.qrCode,
+        botInfo: info.botInfo,
       })
     );
-    ws.on('close', () => clients.delete(ws));
+    ws.on('close', () => {
+      set.delete(ws);
+      if (set.size === 0) clients.delete(userId);
+    });
   });
 }
 
@@ -75,7 +97,7 @@ function start(client, userId) {
           const novoPedidoData = { nome: nomeContato, telefone: telefoneCliente };
           pedido = await pedidoService.criarPedido(db, novoPedidoData, client, userId);
           await pedidoService.updateCamposPedido(db, pedido.id, { mensagemUltimoStatus: 'boas_vindas' }, userId);
-          broadcast({ type: 'novo_contato', pedido });
+          broadcast(userId, { type: 'novo_contato', pedido });
         } else {
           console.log('Criação automática de contato desativada - ignorando mensagem.');
           return;
@@ -84,7 +106,7 @@ function start(client, userId) {
         await pedidoService.incrementarNaoLidas(db, pedido.id, userId);
       }
       await pedidoService.addMensagemHistorico(db, pedido.id, message.body, 'recebida', 'cliente', userId);
-      broadcast({ type: 'nova_mensagem', pedidoId: pedido.id });
+      broadcast(userId, { type: 'nova_mensagem', pedidoId: pedido.id });
     } catch (error) {
       console.error('[onMessage] Erro CRÍTICO ao processar mensagem:', error);
     }
@@ -94,12 +116,13 @@ function start(client, userId) {
 }
 
 async function connectToWhatsApp(userId) {
-  if (activeSessions.has(userId) || whatsappStatus === 'CONNECTING' || whatsappStatus === 'CONNECTED') {
+  const current = sessionData.get(userId);
+  if (activeSessions.has(userId) || (current && (current.status === 'CONNECTING' || current.status === 'CONNECTED'))) {
     console.warn(`⚠️ Tentativa de conectar com sessão já ativa para o usuário ${userId}.`);
     return;
   }
   console.log(`Iniciando conexão com o WhatsApp para usuário ${userId}...`);
-  broadcastStatus('CONNECTING');
+  broadcastStatus(userId, 'CONNECTING');
 
   venom
     .create(
@@ -109,7 +132,7 @@ async function connectToWhatsApp(userId) {
         headless: 'new',
         browserArgs: ['--no-sandbox', '--disable-setuid-sandbox'],
       },
-      (base64Qr) => broadcastStatus('QR_CODE', { qrCode: base64Qr }),
+      (base64Qr) => broadcastStatus(userId, 'QR_CODE', { qrCode: base64Qr }),
       (statusSession) => console.log('[Status da Sessão]', statusSession)
     )
     .then(async (client) => {
@@ -134,21 +157,24 @@ async function connectToWhatsApp(userId) {
             fotoUrl = hostDevice.eurl || null;
           }
 
-          botInfo = { numero: numeroBot, nome: nomeBot, fotoUrl };
-          console.log('Informações do Bot Coletadas:', botInfo);
+          const info = sessionData.get(userId) || { status: 'CONNECTING', qrCode: null, botInfo: null };
+          info.botInfo = { numero: numeroBot, nome: nomeBot, fotoUrl };
+          sessionData.set(userId, info);
+          console.log('Informações do Bot Coletadas:', info.botInfo);
         }
       } catch (error) {
         console.error('❌ Erro ao obter dados do hostDevice:', error);
       } finally {
         start(client, userId);
-        broadcastStatus('CONNECTED', { botInfo });
+        const info = sessionData.get(userId) || { botInfo: null };
+        broadcastStatus(userId, 'CONNECTED', { botInfo: info.botInfo });
       }
     })
     .catch((erro) => {
       console.error('❌ Erro DETALHADO ao criar cliente Venom:', erro);
-      broadcastStatus('DISCONNECTED');
+      broadcastStatus(userId, 'DISCONNECTED');
       activeSessions.delete(userId);
-      botInfo = null;
+      sessionData.set(userId, { status: 'DISCONNECTED', qrCode: null, botInfo: null });
     });
 }
 
@@ -162,8 +188,8 @@ async function disconnectFromWhatsApp(userId) {
       console.error('Erro ao desconectar o cliente:', error);
     } finally {
       activeSessions.delete(userId);
-      botInfo = null;
-      broadcastStatus('DISCONNECTED');
+      sessionData.set(userId, { status: 'DISCONNECTED', qrCode: null, botInfo: null });
+      broadcastStatus(userId, 'DISCONNECTED');
       console.log('🔌 Cliente WhatsApp desconectado.');
     }
   }
@@ -174,8 +200,8 @@ module.exports = {
   connectToWhatsApp,
   disconnectFromWhatsApp,
   broadcast,
-  getStatus: () => whatsappStatus,
-  getQrCode: () => qrCodeData,
-  getBotInfo: () => botInfo,
+  getStatus: (userId) => (sessionData.get(userId) || { status: 'DISCONNECTED' }).status,
+  getQrCode: (userId) => (sessionData.get(userId) || {}).qrCode || null,
+  getBotInfo: (userId) => (sessionData.get(userId) || {}).botInfo || null,
   activeSessions,
 };


### PR DESCRIPTION
## Summary
- keep WhatsApp connection status per user
- authorise WebSocket connections with JWT and send updates only to that user
- update server routes and client script to use tokened WebSocket

## Testing
- `npm install` *(fails: puppeteer download blocked)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bcdf557ac8321b4edb564ef2dfc69