### PR TITLE
Fix cancel integration and add backend validation

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1614,7 +1614,12 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
         integrationSetupView.dataset.mode = '';
     }
 
-    async function cancelIntegrationSetup() {
+    async function cancelIntegrationSetup(event) {
+        if (event) event.preventDefault();
+        const nameInput = document.getElementById('integration-name');
+        const secretInput = document.getElementById('integration-secret');
+        if (nameInput) nameInput.value = '';
+        if (secretInput) secretInput.value = '';
         showIntegrationsList();
         loadAndRenderIntegrations();
     }

--- a/src/controllers/integrationsController.js
+++ b/src/controllers/integrationsController.js
@@ -119,16 +119,16 @@ exports.criarIntegracao = async (req, res) => {
     if (!name || !name.trim()) {
         return res.status(400).json({ error: 'Nome da integração é obrigatório.' });
     }
-    if (secret_key !== undefined && !secret_key.trim()) {
-        return res.status(400).json({ error: 'A chave secreta não pode estar vazia.' });
+    if (!secret_key || !secret_key.trim()) {
+        return res.status(400).json({ error: 'A chave secreta é obrigatória.' });
     }
 
     try {
         const uniquePath = crypto.randomBytes(16).toString('hex');
 
-        const sql = 'INSERT INTO integrations (user_id, platform, name, unique_path) VALUES (?, ?, ?, ?)';
+        const sql = 'INSERT INTO integrations (user_id, platform, name, unique_path, secret_key) VALUES (?, ?, ?, ?, ?)';
         const newIntegrationId = await new Promise((resolve, reject) => {
-            db.run(sql, [clienteId, platform, name, uniquePath], function(err) {
+            db.run(sql, [clienteId, platform, name, uniquePath, secret_key], function(err) {
                 if (err) return reject(err);
                 resolve(this.lastID);
             });


### PR DESCRIPTION
## Summary
- ensure cancel integration clears the form without sending data
- validate integration fields and store secret key in DB on creation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bfaf8eea48321945f2e4927e36c7b